### PR TITLE
configure: fix for `-Werror=implicit-function-declaration`

### DIFF
--- a/configure
+++ b/configure
@@ -3481,8 +3481,8 @@ main ()
   for (i = 0; i < 256; i++)
     if (XOR (islower (i), ISLOWER (i))
 	|| toupper (i) != TOUPPER (i))
-      exit(2);
-  exit (0);
+      return 2;
+  return 0;
 }
 _ACEOF
 rm -f conftest$ac_exeext


### PR DESCRIPTION
Older autoconf used implicit function declarations in tests, which Xcode Clang ≥ 12 and LLVM.org Clang ≥ 16 consider errors by default rather than warnings. This has affected many projects and can cause them to misconfigure, however this is the only notice I notice in TkZinc’s configure:
```
checking for ANSI C header files... no
```

In config.log:
```
conftest.c:26:7: error: call to undeclared library function 'exit' with type 'void (int) __attribute__((noreturn))'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   26 |       exit(2);
      |       ^
conftest.c:26:7: note: include the header <stdlib.h> or explicitly provide a declaration for 'exit'
1 error generated.
```

I do not know how involved it is to regenerate TkZinc’s configure script with newer autoconf, so I suggest patching it for now (using approach backported from https://github.com/autotools-mirror/autoconf/commit/a71c24a704ec0570ba99be909fffbc044d50908b#diff-c44abe5911b20c8b4e6ea7a042e45554f275792d406575ae6e5e2d596c877f66).