### PR TITLE
configure: fix for C23

### DIFF
--- a/configure
+++ b/configure
@@ -2651,9 +2651,7 @@ cat >>conftest.$ac_ext <<_ACEOF
 /* Most of the following tests are stolen from RCS 5.7's src/conf.sh.  */
 struct buf { int x; };
 FILE * (*rcsopen) (struct buf *, struct stat *, int);
-static char *e (p, i)
-     char **p;
-     int i;
+static char *e (char **p, int i)
 {
   return p[i];
 }


### PR DESCRIPTION
Newer compilers already warn about K&R-style function definitions:

```
conftest.c:16:14: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
   16 | static char *e (p, i)
      |              ^
1 warning generated.
```

Error when `-std=c2x` is used:
```
conftest.c:16:17: error: unknown type name 'p'
   16 | static char *e (p, i)
      |                 ^
conftest.c:16:20: error: unknown type name 'i'
   16 | static char *e (p, i)
      |                    ^
conftest.c:16:22: error: expected ';' after top level declarator
   16 | static char *e (p, i)
      |                      ^
      |                      ;
conftest.c:19:1: error: expected identifier or '('
   19 | {
      | ^
4 errors generated.
```



This is fixed in recent autoconf: https://github.com/autotools-mirror/autoconf/commit/bf5a75953b6d504f0405b1ca33b039b8dd39eef4#diff-855d7e7c5d20b409359c0c48e0b1e07d253b716ad5ceda9a981a60271eb33426