### PR TITLE
tkZinc.h: fix XQuartz build

### DIFF
--- a/generic/tkZinc.h
+++ b/generic/tkZinc.h
@@ -88,7 +88,7 @@ typedef struct _ZnGLContextEntry {
   int           ipixel;
   HWND          hwnd;   /* Temporary storage between MakeCurrent and Release */
   HDC           hdc;
-#elif defined(__APPLE__)
+#elif defined(MAC_OSX_TK)
   AGLPixelFormat pix_fmt;
   GWorldPtr     gworld;
   Tk_Window     top_win;


### PR DESCRIPTION
I encountered this error when building for XQuartz, i.e. Tk X11 rather than Tk Aqua:
```
./generic/tkZinc.h:92:3: error: unknown type name 'AGLPixelFormat'
   92 |   AGLPixelFormat pix_fmt;
      |   ^
./generic/tkZinc.h:93:3: error: unknown type name 'GWorldPtr'
   93 |   GWorldPtr     gworld;
      |   ^
```

Including AGL/agl.h causes both of these types to be defined, and this header is included by Types.h for `MAC_OSX_TK` (i.e. Tk Aqua rather than Tk X11). So `MAC_OSX_TK` would also be the correct macro to check in the `ZnGLContextEntry` declaration.

I have not built TkZinc for Tk Aqua, though, and presumably it has to be migrated from Carbon to Cocoa to build with recent Tk Aqua (≥8.5.13).