### PR TITLE
Remove `rcsid[]` and `compile_id[]`

### DIFF
--- a/generic/Arc.c
+++ b/generic/Arc.c
@@ -25,8 +25,6 @@
 #include "tkZinc.h"
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 /*

--- a/generic/Attrs.c
+++ b/generic/Attrs.c
@@ -31,8 +31,6 @@
 #include <stdlib.h>
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 /*

--- a/generic/Curve.c
+++ b/generic/Curve.c
@@ -31,8 +31,6 @@
 #endif
 #include <ctype.h>
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 /*

--- a/generic/Field.c
+++ b/generic/Field.c
@@ -27,8 +27,6 @@
 #include <stdlib.h>
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 #define FIELD_SENSITIVE_BIT     1

--- a/generic/Geo.c
+++ b/generic/Geo.c
@@ -26,8 +26,6 @@
 #include <memory.h>
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 void

--- a/generic/Group.c
+++ b/generic/Group.c
@@ -28,8 +28,6 @@
 #endif
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 /*

--- a/generic/Icon.c
+++ b/generic/Icon.c
@@ -23,8 +23,6 @@
 #include "tkZinc.h"
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[] = "$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 /*

--- a/generic/Image.c
+++ b/generic/Image.c
@@ -29,8 +29,6 @@
 #endif
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[] = "$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 static int              images_inited = 0;

--- a/generic/Item.c
+++ b/generic/Item.c
@@ -42,8 +42,6 @@
 #include <string.h>
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 static  ZnList  item_classes = NULL;

--- a/generic/Map.c
+++ b/generic/Map.c
@@ -29,8 +29,6 @@
 #include <stdio.h>
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 /*

--- a/generic/MapInfo.c
+++ b/generic/MapInfo.c
@@ -31,8 +31,6 @@
 
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 /*

--- a/generic/OverlapMan.c
+++ b/generic/OverlapMan.c
@@ -24,8 +24,6 @@
  *   dealing with tracks.
  */
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 #include "OverlapMan.h"

--- a/generic/PostScript.c
+++ b/generic/PostScript.c
@@ -55,8 +55,6 @@
  **********************************************************************************
  */
 
-static  const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 /*

--- a/generic/Rectangle.c
+++ b/generic/Rectangle.c
@@ -26,8 +26,6 @@
 #include "tkZinc.h"
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 /*
  * Bit offset of flags.

--- a/generic/Reticle.c
+++ b/generic/Reticle.c
@@ -25,8 +25,6 @@
 #include <math.h>
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 /*

--- a/generic/Tabular.c
+++ b/generic/Tabular.c
@@ -26,8 +26,6 @@
 #include <stdlib.h>
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 /*

--- a/generic/Text.c
+++ b/generic/Text.c
@@ -37,8 +37,6 @@
 #include "Image.h"
 
 
-static const char rcsid[] = "$Imagine: Text.c,v 1.13 1997/05/15 11:35:46 lecoanet Exp $";
-static const char compile_id[] = "$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 /*

--- a/generic/Track.c
+++ b/generic/Track.c
@@ -30,8 +30,6 @@
 #include <stdlib.h>
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 /*
  * Define this to enable overlap manager setting

--- a/generic/Transfo.c
+++ b/generic/Transfo.c
@@ -39,8 +39,6 @@
 #include <stdlib.h>
 
 
-static const char rcsid[] = "$Imagine: Transfo.c,v 1.7 1997/01/24 14:33:37 lecoanet Exp $";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 

--- a/generic/perfos.c
+++ b/generic/perfos.c
@@ -29,8 +29,6 @@
 #include <sys/times.h>
 
 
-static const char rcsid[] = "$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 
 static ZnList   Chronos = NULL;


### PR DESCRIPTION
These are unused, which compilers about warn by default:
```
./generic/Viewport.c:56:19: warning: unused variable 'rcsid' [-Wunused-const-variable]
   56 | static const char rcsid[] = "$Id$";
      |                   ^~~~~
./generic/Viewport.c:57:19: warning: unused variable 'compile_id' [-Wunused-const-variable]
   57 | static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
      |                   ^~~~~~~~~~
```

The use of `__DATE__` and `__TIME__` also hinders “deterministic”/“reproducible” building and prevents effective ccache use; see e.g. https://blog.llvm.org/2019/11/deterministic-builds-with-clang-and-lld.html