### PR TITLE
Remove `_ANSI_ARGS_()` usage; Migrate `CONST` usage to `const`

### DIFF
--- a/Perl/Zinc.xs
+++ b/Perl/Zinc.xs
@@ -25,21 +25,21 @@ ZincObjCmd(
 	   ClientData client_data,
 	   Tcl_Interp* interp,
 	   int argc,
-	   Tcl_Obj* CONST args[]);
+	   Tcl_Obj* const args[]);
 
 extern int
 ZnVideomapObjCmd(
 	         ClientData client_data,
 	         Tcl_Interp* interp,
 	         int argc,
-	         Tcl_Obj* CONST args[]);
+	         Tcl_Obj* const args[]);
 
 extern int
 ZnMapInfoObjCmd(
 	        ClientData client_data,
 	        Tcl_Interp* interp,
 	        int argc,
-	        Tcl_Obj* CONST args[]);
+	        Tcl_Obj* const args[]);
 
 DECLARE_VTABLES;
 TkimgphotoVtab *TkimgphotoVptr;

--- a/generic/Arc.c
+++ b/generic/Arc.c
@@ -142,7 +142,7 @@ static ZnAttrConfig     arc_attrs[] = {
 static int
 Init(ZnItem             item,
      int                *argc,
-      Tcl_Obj *CONST    *args[])
+      Tcl_Obj *const    *args[])
 {
   ZnWInfo       *wi = item->wi;
   ArcItem       arc = (ArcItem) item;
@@ -299,7 +299,7 @@ SetRenderFlags(ArcItem  arc)
 static int
 Configure(ZnItem        item,
           int           argc,
-          Tcl_Obj *CONST argv[],
+          Tcl_Obj *const argv[],
           int           *flags)
 {
   ArcItem       arc = (ArcItem) item;
@@ -326,7 +326,7 @@ Configure(ZnItem        item,
 static int
 Query(ZnItem            item,
       int                   argc,
-      Tcl_Obj *CONST    argv[])
+      Tcl_Obj *const    argv[])
 {
   if (ZnQueryAttribute(item->wi->interp, item, arc_attrs, argv[0]) == TCL_ERROR) {
     return TCL_ERROR;

--- a/generic/Curve.c
+++ b/generic/Curve.c
@@ -163,7 +163,7 @@ static ZnAttrConfig     cv_attrs[] = {
 static int
 Init(ZnItem             item,
      int                *argc,
-     Tcl_Obj *CONST     *args[])
+     Tcl_Obj *const     *args[])
 {
   ZnWInfo       *wi = item->wi;
   CurveItem     cv = (CurveItem) item;
@@ -443,7 +443,7 @@ SetRenderFlags(CurveItem        cv)
 static int
 Configure(ZnItem        item,
           int           argc,
-          Tcl_Obj *CONST argv[],
+          Tcl_Obj *const argv[],
           int           *flags)
 {
   ZnWInfo       *wi = item->wi;
@@ -482,7 +482,7 @@ Configure(ZnItem        item,
 static int
 Query(ZnItem            item,
       int               argc,
-      Tcl_Obj *CONST    argv[])
+      Tcl_Obj *const    argv[])
 {
   if (ZnQueryAttribute(item->wi->interp, item, cv_attrs, argv[0]) == TCL_ERROR) {
     return TCL_ERROR;

--- a/generic/Field.c
+++ b/generic/Field.c
@@ -922,7 +922,7 @@ static int
 ConfigureField(ZnFieldSet       fs,
                int              field,
                int              argc,
-               Tcl_Obj *CONST   argv[],
+               Tcl_Obj *const   argv[],
                int              *flags)
 {
   unsigned int  i;
@@ -1043,7 +1043,7 @@ static int
 QueryField(ZnFieldSet           fs,
            int                  field,
            int                  argc,
-           Tcl_Obj *CONST       argv[])
+           Tcl_Obj *const       argv[])
 {
   if ((field < 0) || ((unsigned int) field >= fs->num_fields)) {
     Tcl_AppendResult(fs->item->wi->interp, "invalid field index \"", NULL);

--- a/generic/Field.h
+++ b/generic/Field.h
@@ -56,8 +56,8 @@ extern struct _ZnFIELD {
   void (*InitFields)(ZnFieldSet fs);
   void (*CloneFields)(ZnFieldSet fs);
   void (*FreeFields)(ZnFieldSet fs);
-  int (*ConfigureField)(ZnFieldSet fs, int field, int argc, Tcl_Obj *CONST argv[], int *flags);
-  int (*QueryField)(ZnFieldSet fs, int field, int argc, Tcl_Obj *CONST argv[]);
+  int (*ConfigureField)(ZnFieldSet fs, int field, int argc, Tcl_Obj *const argv[], int *flags);
+  int (*QueryField)(ZnFieldSet fs, int field, int argc, Tcl_Obj *const argv[]);
   void (*DrawFields)(ZnFieldSet fs);
   void (*RenderFields)(ZnFieldSet fs);
   int (*PostScriptFields)(ZnFieldSet fs, ZnBool prepass, ZnBBox *area);

--- a/generic/Group.c
+++ b/generic/Group.c
@@ -111,7 +111,7 @@ static ZnAttrConfig     group_attrs[] = {
 static int
 Init(ZnItem             item,
      int                *argc,
-     Tcl_Obj *CONST     *args[])
+     Tcl_Obj *const     *args[])
 {
   GroupItem     group = (GroupItem) item;
   
@@ -419,7 +419,7 @@ SetXShape(ZnItem        grp)
 static int
 Configure(ZnItem        item,
           int           argc,
-          Tcl_Obj *CONST argv[],
+          Tcl_Obj *const argv[],
           int           *flags)
 {
   GroupItem     group = (GroupItem) item;
@@ -460,7 +460,7 @@ Configure(ZnItem        item,
 static int
 Query(ZnItem            item,
       int               argc,
-      Tcl_Obj *CONST    argv[])
+      Tcl_Obj *const    argv[])
 {
   if (ZnQueryAttribute(item->wi->interp, item, group_attrs, argv[0]) == TCL_ERROR) {
     return TCL_ERROR;

--- a/generic/Icon.c
+++ b/generic/Icon.c
@@ -103,7 +103,7 @@ static ZnAttrConfig     icon_attrs[] = {
 static int
 Init(ZnItem             item,
      int                *argc,
-     Tcl_Obj *CONST     *args[])
+     Tcl_Obj *const     *args[])
 {
   ZnWInfo       *wi = item->wi;
   IconItem      icon = (IconItem) item;
@@ -179,7 +179,7 @@ Destroy(ZnItem  item)
 static int
 Configure(ZnItem        item,
           int           argc,
-          Tcl_Obj *CONST argv[],
+          Tcl_Obj *const argv[],
           int           *flags)
 {
   ZnItem        old_connected;
@@ -220,7 +220,7 @@ Configure(ZnItem        item,
 static int
 Query(ZnItem            item,
       int               argc,
-      Tcl_Obj *CONST    argv[])
+      Tcl_Obj *const    argv[])
 {
   if (ZnQueryAttribute(item->wi->interp, item, icon_attrs, argv[0]) == TCL_ERROR) {
     return TCL_ERROR;

--- a/generic/Image.c
+++ b/generic/Image.c
@@ -1152,7 +1152,7 @@ SuckGlyphsFromServer(ZnWInfo    *wi,
   unsigned int  numToGrab, glyph;
   ZnTexGVI      *tgvip;
   Tk_FontMetrics fm;
-  CONST unsigned char   *cur, *next;
+  const unsigned char   *cur, *next;
 #ifndef PTK_800
   Tcl_UniChar   uni_ch;
 #endif

--- a/generic/Item.c
+++ b/generic/Item.c
@@ -250,7 +250,7 @@ ZnAttributesInfo(Tcl_Interp     *interp,
                  void           *record,
                  ZnAttrConfig   *desc_table,
                  int            argc,
-                 Tcl_Obj *CONST args[])
+                 Tcl_Obj *const args[])
 {
   Tcl_Obj       *l, *entries[5];
   
@@ -298,7 +298,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
                       void              *record,
                       ZnAttrConfig      *desc_table,
                       int               argc,
-                      Tcl_Obj *CONST    args[],
+                      Tcl_Obj *const    args[],
                       int               *flags)
 {
   int           i;
@@ -1669,7 +1669,7 @@ ZnItem
 ZnCreateItem(ZnWInfo        *wi,
              ZnItemClass   item_class,
              int            *argc,
-             Tcl_Obj *CONST *args[])
+             Tcl_Obj *const *args[])
 {
   ZnItem        item;
 
@@ -1776,7 +1776,7 @@ static int
 ConfigureItem(ZnItem            item,
               int               field,
               int               argc,
-              Tcl_Obj   *CONST  argv[],
+              Tcl_Obj   *const  argv[],
               ZnBool            init)
 {
   ZnWInfo       *wi = item->wi;
@@ -1835,7 +1835,7 @@ static int
 QueryItem(ZnItem                item,
           int                   field,
           int                   argc,
-          Tcl_Obj *CONST        argv[])
+          Tcl_Obj *const        argv[])
 {
   if (field < 0) {
     return item->class->Query(item, argc, argv);

--- a/generic/Item.c
+++ b/generic/Item.c
@@ -94,7 +94,7 @@ static char *attribute_type_strings[] = {
 
 
 #ifndef PTK
-static int SetAttrFromAny _ANSI_ARGS_((Tcl_Interp *interp, Tcl_Obj *obj));
+static int SetAttrFromAny(Tcl_Interp *interp, Tcl_Obj *obj);
 
 /*
  * The structure below defines an object type that is used to cache the

--- a/generic/Item.h
+++ b/generic/Item.h
@@ -211,10 +211,10 @@ typedef struct _ZnPickStruct {
 /*
  * Item class record --
  */
-typedef int (*ZnItemInitMethod)(ZnItem item, int *argc, Tcl_Obj *CONST *args[]);
-typedef int (*ZnItemConfigureMethod)(ZnItem item, int argc, Tcl_Obj *CONST args[],
+typedef int (*ZnItemInitMethod)(ZnItem item, int *argc, Tcl_Obj *const *args[]);
+typedef int (*ZnItemConfigureMethod)(ZnItem item, int argc, Tcl_Obj *const args[],
                                      int *flags);
-typedef int (*ZnItemQueryMethod)(ZnItem item, int argc, Tcl_Obj *CONST args[]);
+typedef int (*ZnItemQueryMethod)(ZnItem item, int argc, Tcl_Obj *const args[]);
 typedef void (*ZnItemCloneMethod)(ZnItem item);
 typedef void (*ZnItemDestroyMethod)(ZnItem item);
 typedef void (*ZnItemDrawMethod)(ZnItem item);
@@ -299,9 +299,9 @@ typedef struct _ZnItemClassStruct {
 extern struct _ZnITEM {
   ZnItem (*CloneItem)(ZnItem model);
   void (*DestroyItem)(ZnItem item);
-  int (*ConfigureItem)(ZnItem item, int field, int argc, Tcl_Obj *CONST args[],
+  int (*ConfigureItem)(ZnItem item, int field, int argc, Tcl_Obj *const args[],
                        ZnBool init);
-  int (*QueryItem)(ZnItem item, int field, int argc, Tcl_Obj *CONST args[]);
+  int (*QueryItem)(ZnItem item, int field, int argc, Tcl_Obj *const args[]);
   void (*InsertItem)(ZnItem item, ZnItem group, ZnItem mark_item, ZnBool before);
   void (*UpdateItemPriority)(ZnItem item, ZnItem mark_item, ZnBool before);
   void (*UpdateItemDependency)(ZnItem item, ZnItem old_connection);
@@ -333,15 +333,15 @@ extern struct _ZnITEM {
  */
 void ZnItemInit();
 ZnItem ZnCreateItem(struct _ZnWInfo *wi, ZnItemClass item_class,
-                  int *argc, Tcl_Obj *CONST *args[]);
+                  int *argc, Tcl_Obj *const *args[]);
 void ZnAddItemClass(ZnItemClass class);
 ZnItemClass ZnLookupItemClass(char *class_name);
 ZnList ZnItemClassList();
 int ZnConfigureAttributes(struct _ZnWInfo *wi, ZnItem item, void *record,
-                          ZnAttrConfig *attr_desc, int argc, Tcl_Obj *CONST args[],
+                          ZnAttrConfig *attr_desc, int argc, Tcl_Obj *const args[],
                           int *flags);
 int ZnAttributesInfo(Tcl_Interp *interp, void *record,
-                     ZnAttrConfig *attr_desc, int argc, Tcl_Obj *CONST args[]);
+                     ZnAttrConfig *attr_desc, int argc, Tcl_Obj *const args[]);
 int ZnQueryAttribute(Tcl_Interp *interp, void *record, ZnAttrConfig *attr_desc,
                      Tcl_Obj *attr_name);
 void ZnInitTransformStack(struct _ZnWInfo *wi);

--- a/generic/Map.c
+++ b/generic/Map.c
@@ -185,7 +185,7 @@ FreeLists(MapItem       map)
 static int
 Init(ZnItem             item,
      int                *argc,
-     Tcl_Obj *CONST     *args[])
+     Tcl_Obj *const     *args[])
 {
   MapItem       map  = (MapItem) item;
   ZnWInfo       *wi = item->wi;
@@ -368,7 +368,7 @@ Destroy(ZnItem  item)
 static int
 Configure(ZnItem        item,
           int           argc,
-          Tcl_Obj *CONST argv[],
+          Tcl_Obj *const argv[],
           int           *flags)
 {
   ZnWInfo       *wi = item->wi;
@@ -428,7 +428,7 @@ Configure(ZnItem        item,
 static int
 Query(ZnItem            item,
       int               argc,
-      Tcl_Obj *CONST    argv[])
+      Tcl_Obj *const    argv[])
 {
   if (ZnQueryAttribute(item->wi->interp, item, map_attrs, argv[0]) == TCL_ERROR) {
     return TCL_ERROR;

--- a/generic/MapInfo.c
+++ b/generic/MapInfo.c
@@ -1569,7 +1569,7 @@ int
 ZnMapInfoObjCmd(ClientData      client_data,
                 Tcl_Interp      *interp,        /* Current interpreter. */
                 int             argc,           /* Number of arguments. */
-                Tcl_Obj *CONST  args[])
+                Tcl_Obj *const  args[])
 {
   ZnPos           x, y;
   int             index, index2, result;
@@ -1578,7 +1578,7 @@ ZnMapInfoObjCmd(ClientData      client_data,
 #ifdef PTK_800
   static char *sub_cmd_strings[] =
 #else
-  static CONST char *sub_cmd_strings[] =
+  static const char *sub_cmd_strings[] =
 #endif
   {
     "add", "count", "create", "delete", "duplicate",
@@ -1587,7 +1587,7 @@ ZnMapInfoObjCmd(ClientData      client_data,
 #ifdef PTK_800
   static char *e_type_strings[] =
 #else
-  static CONST char *e_type_strings[] =
+  static const char *e_type_strings[] =
 #endif
   {
     "arc", "line", "symbol", "text", NULL
@@ -2048,7 +2048,7 @@ int
 ZnVideomapObjCmd(ClientData     client_data,
                  Tcl_Interp     *interp,        /* Current interpreter. */
                  int            argc,           /* Number of arguments. */
-                 Tcl_Obj        *CONST  args[])
+                 Tcl_Obj        *const  args[])
 {
   ZnList        ids;
   int           index;
@@ -2057,7 +2057,7 @@ ZnVideomapObjCmd(ClientData     client_data,
 #ifdef PTK_800
   static char *sub_cmd_strings[] =
 #else
-  static CONST char *sub_cmd_strings[] =
+  static const char *sub_cmd_strings[] =
 #endif
   {
     "ids", "load", NULL

--- a/generic/MapInfo.h
+++ b/generic/MapInfo.h
@@ -83,9 +83,9 @@ void ZnFreeMapInfo(ZnMapInfoId map_info, ZnMapInfoChangeProc proc,
                    ClientData client_data);
 
 int ZnMapInfoObjCmd(ClientData client_data, Tcl_Interp *interp,
-                    int argc, Tcl_Obj *CONST args[]);
+                    int argc, Tcl_Obj *const args[]);
 int ZnVideomapObjCmd(ClientData client_data, Tcl_Interp *interp,
-                     int argc, Tcl_Obj *CONST args[]);
+                     int argc, Tcl_Obj *const args[]);
   
 
 #ifdef __CPLUSPLUS__

--- a/generic/PostScript.c
+++ b/generic/PostScript.c
@@ -242,14 +242,14 @@ GetPostscriptPoints(Tcl_Interp *interp,
 int
 ZnPostScriptCmd(ZnWInfo        *wi,
                 int            argc,
-                Tcl_Obj *CONST argv[])
+                Tcl_Obj *const argv[])
 {
   TkPostscriptInfo  ps_info;
   Tk_PostscriptInfo old_info;
   int               result;
 #define STRING_LENGTH 400
   char              string[STRING_LENGTH+1];
-  CONST char        *p;
+  const char        *p;
   time_t            now;
   size_t            length;
   Tk_Window         tkwin = wi->win;
@@ -303,7 +303,7 @@ ZnPostScriptCmd(ZnWInfo        *wi,
   ps_info.prolog = 1;
   Tcl_InitHashTable(&ps_info.fontTable, TCL_STRING_KEYS);
   result = Tk_ConfigureWidget(wi->interp, wi->win, config_specs,
-                              argc-2, (CONST char **) argv+2,
+                              argc-2, (const char **) argv+2,
                               (char *) &ps_info,
                               TK_CONFIG_ARGV_ONLY|TK_CONFIG_OBJS);
   if (result != TCL_OK) {
@@ -798,7 +798,7 @@ ZnPostscriptString(Tcl_Interp   *interp,
 
   int         used, len, clen;
   int         c, bytecount = 0;
-  CONST char  *p, *last_p, *glyphname;
+  const char  *p, *last_p, *glyphname;
   Tcl_UniChar ch;
   char        charbuf[5];
 #define MAXUSE 500

--- a/generic/PostScript.h
+++ b/generic/PostScript.h
@@ -34,7 +34,7 @@ struct _ZnWInfo;
 struct _ZnItemStruct;
 
 
-int ZnPostScriptCmd(struct _ZnWInfo *wi, int argc, Tcl_Obj *CONST *args);
+int ZnPostScriptCmd(struct _ZnWInfo *wi, int argc, Tcl_Obj *const *args);
 void ZnFlushPsChan(Tcl_Interp *interp, Tk_PostscriptInfo ps_info);
 int ZnPostscriptOutline(Tcl_Interp *interp, Tk_PostscriptInfo ps_info,
                         Tk_Window tkwin, ZnDim line_width, ZnLineStyle line_style,

--- a/generic/Rectangle.c
+++ b/generic/Rectangle.c
@@ -123,7 +123,7 @@ static ZnAttrConfig     rect_attrs[] = {
 static int
 Init(ZnItem             item,
      int                *argc,
-     Tcl_Obj *CONST     *args[])
+     Tcl_Obj *const     *args[])
 {
   ZnWInfo       *wi = item->wi;
   RectangleItem rect = (RectangleItem) item;
@@ -240,7 +240,7 @@ Destroy(ZnItem  item)
 static int
 Configure(ZnItem        item,
           int           argc,
-          Tcl_Obj *CONST argv[],
+          Tcl_Obj *const argv[],
           int           *flags)
 {
   ZnWInfo       *wi = item->wi;
@@ -279,7 +279,7 @@ Configure(ZnItem        item,
 static int
 Query(ZnItem            item,
       int               argc,
-      Tcl_Obj *CONST    argv[])
+      Tcl_Obj *const    argv[])
 {
   if (ZnQueryAttribute(item->wi->interp, item, rect_attrs, argv[0]) == TCL_ERROR) {
     return TCL_ERROR;

--- a/generic/Reticle.c
+++ b/generic/Reticle.c
@@ -128,7 +128,7 @@ static ZnAttrConfig     reticle_attrs[] = {
 static int
 Init(ZnItem             item,
      int                *argc,
-     Tcl_Obj *CONST     *args[])     
+     Tcl_Obj *const     *args[])
 {
   ReticleItem   reticle = (ReticleItem) item;
   ZnWInfo       *wi = item->wi;
@@ -204,7 +204,7 @@ Destroy(ZnItem  item)
 static int
 Configure(ZnItem        item,
           int           argc,
-          Tcl_Obj *CONST argv[],
+          Tcl_Obj *const argv[],
           int           *flags)
 {
   if (ZnConfigureAttributes(item->wi, item, item, reticle_attrs,
@@ -226,7 +226,7 @@ Configure(ZnItem        item,
 static int
 Query(ZnItem            item,
       int               argc,
-      Tcl_Obj *CONST    argv[])
+      Tcl_Obj *const    argv[])
 {
   if (ZnQueryAttribute(item->wi->interp, item, reticle_attrs, argv[0]) == TCL_ERROR) {
     return TCL_ERROR;

--- a/generic/Tabular.c
+++ b/generic/Tabular.c
@@ -101,7 +101,7 @@ static ZnAttrConfig     tabular_attrs[] = {
 static int
 Init(ZnItem             item,
      int                *argc,
-     Tcl_Obj *CONST     *args[])
+     Tcl_Obj *const     *args[])
 {
   ZnWInfo       *wi = item->wi;
   TabularItem   tab = (TabularItem) item;
@@ -186,7 +186,7 @@ Destroy(ZnItem  item)
 static int
 Configure(ZnItem        item,
           int           argc,
-          Tcl_Obj *CONST argv[],
+          Tcl_Obj *const argv[],
           int           *flags)
 {
   ZnItem        old_connected;
@@ -226,7 +226,7 @@ Configure(ZnItem        item,
 static int
 Query(ZnItem            item,
       int               argc,
-      Tcl_Obj *CONST    argv[])
+      Tcl_Obj *const    argv[])
 {
   if (ZnQueryAttribute(item->wi->interp, item, tabular_attrs, argv[0]) == TCL_ERROR) {
     return TCL_ERROR;

--- a/generic/Text.c
+++ b/generic/Text.c
@@ -162,7 +162,7 @@ static ZnAttrConfig     text_attrs[] = {
 static int
 Init(ZnItem             item,
      int                *argc,
-     Tcl_Obj *CONST     *args[])
+     Tcl_Obj *const     *args[])
 {
   ZnWInfo       *wi = item->wi;
   TextItem      text = (TextItem) item;
@@ -285,7 +285,7 @@ Destroy(ZnItem  item)
 static int
 Configure(ZnItem        item,
           int           argc,
-          Tcl_Obj *CONST argv[],
+          Tcl_Obj *const argv[],
           int           *flags)
 {
   TextItem      text = (TextItem) item;
@@ -366,7 +366,7 @@ Configure(ZnItem        item,
 static int
 Query(ZnItem            item,
       int               argc,
-      Tcl_Obj *CONST    argv[])
+      Tcl_Obj *const    argv[])
 {
   if (ZnQueryAttribute(item->wi->interp, item, text_attrs, argv[0]) == TCL_ERROR) {
     return TCL_ERROR;

--- a/generic/Track.c
+++ b/generic/Track.c
@@ -375,7 +375,7 @@ static ZnAttrConfig     wp_attrs[] = {
 static int
 Init(ZnItem             item,
      int                *argc,
-     Tcl_Obj *CONST     *args[])
+     Tcl_Obj *const     *args[])
 {
   TrackItem     track = (TrackItem) item;
   ZnFieldSet    field_set = &track->field_set;
@@ -631,7 +631,7 @@ AddToHistory(TrackItem  track,
 static int
 Configure(ZnItem        item,
           int           argc,
-          Tcl_Obj *CONST argv[],
+          Tcl_Obj *const argv[],
           int           *flags)
 {
   TrackItem     track = (TrackItem) item;
@@ -708,7 +708,7 @@ Configure(ZnItem        item,
 static int
 Query(ZnItem            item,
       int               argc,
-      Tcl_Obj *CONST    argv[])
+      Tcl_Obj *const    argv[])
 {
   if (ZnQueryAttribute(item->wi->interp, item, track_attrs, argv[0]) == TCL_ERROR) {
     return TCL_ERROR;

--- a/generic/Triangles.c
+++ b/generic/Triangles.c
@@ -101,7 +101,7 @@ static ZnAttrConfig     tr_attrs[] = {
 static int
 Init(ZnItem             item,
      int                *argc,
-     Tcl_Obj *CONST     *args[])
+     Tcl_Obj *const     *args[])
 {
   ZnWInfo       *wi = item->wi;
   TrianglesItem tr = (TrianglesItem) item;
@@ -221,7 +221,7 @@ Destroy(ZnItem  item)
 static int
 Configure(ZnItem        item,
           int           argc,
-          Tcl_Obj *CONST argv[],
+          Tcl_Obj *const argv[],
           int           *flags)
 {
   int           status = TCL_OK;
@@ -242,7 +242,7 @@ Configure(ZnItem        item,
 static int
 Query(ZnItem            item,
       int               argc,
-      Tcl_Obj *CONST    argv[])
+      Tcl_Obj *const    argv[])
 {
   if (ZnQueryAttribute(item->wi->interp, item, tr_attrs, argv[0]) == TCL_ERROR) {
     return TCL_ERROR;

--- a/generic/Viewport.c
+++ b/generic/Viewport.c
@@ -170,7 +170,7 @@ static ZnAttrConfig     viewport_attrs[] = {
 static int
 Init(ZnItem             item,
      int                *argc,
-     Tcl_Obj *CONST     *args[])
+     Tcl_Obj *const     *args[])
 {
   ZnWInfo       *wi = item->wi;
   ViewportItem  rect = (ViewportItem) item;
@@ -330,7 +330,7 @@ Destroy(ZnItem  item)
 static int
 Configure(ZnItem        item,
           int           argc,
-          Tcl_Obj *CONST argv[],
+          Tcl_Obj *const argv[],
           int           *flags)
 {
   ZnWInfo       * wi = item->wi;
@@ -428,7 +428,7 @@ Configure(ZnItem        item,
 static int
 Query(ZnItem            item,
       int               argc,
-      Tcl_Obj *CONST    argv[])
+      Tcl_Obj *const    argv[])
 {
   if (ZnQueryAttribute(item->wi->interp, item, viewport_attrs, argv[0]) == TCL_ERROR) {
     return TCL_ERROR;

--- a/generic/Window.c
+++ b/generic/Window.c
@@ -365,7 +365,7 @@ WindowReleaseExternalWindow(ZnItem item)
 static int
 Init(ZnItem             item,
      int                *argc,
-     Tcl_Obj *CONST     *args[])
+     Tcl_Obj *const     *args[])
 {
   WindowItem    wind = (WindowItem) item;
 
@@ -460,7 +460,7 @@ Destroy(ZnItem  item)
 static int
 Configure(ZnItem        item,
           int           argc,
-          Tcl_Obj *CONST argv[],
+          Tcl_Obj *const argv[],
           int           *flags)
 {
   WindowItem    wind = (WindowItem) item;
@@ -545,7 +545,7 @@ Configure(ZnItem        item,
 static int
 Query(ZnItem            item,
       int               argc,
-      Tcl_Obj *CONST    argv[])
+      Tcl_Obj *const    argv[])
 {
   if (ZnQueryAttribute(item->wi->interp, item, wind_attrs, argv[0]) == TCL_ERROR) {
     return TCL_ERROR;

--- a/generic/tkZinc.c
+++ b/generic/tkZinc.c
@@ -168,31 +168,31 @@ static  int             ZnGLAttribs[] = {
 
 
 #if defined(GL) && defined(ROTATION)
-static void TransformEvent _ANSI_ARGS_((ZnWInfo *wi, XEvent  *event));
+static void TransformEvent(ZnWInfo *wi, XEvent  *event);
 #endif
-static  void PickCurrentItem _ANSI_ARGS_((ZnWInfo *wi, XEvent *event));
+static  void PickCurrentItem(ZnWInfo *wi, XEvent *event);
 #ifdef PTK_800
-static  int ZnReliefParse _ANSI_ARGS_((ClientData client_data, Tcl_Interp *interp,
+static  int ZnReliefParse(ClientData client_data, Tcl_Interp *interp,
                                        Tk_Window tkwin, Tcl_Obj *ovalue,
-                                       char *widget_rec, int offset));
-static  Tcl_Obj *ZnReliefPrint _ANSI_ARGS_((ClientData client_data, Tk_Window tkwin,
+                                       char *widget_rec, int offset);
+static  Tcl_Obj *ZnReliefPrint(ClientData client_data, Tk_Window tkwin,
                                             char *widget_rec, int offset,
-                                            Tcl_FreeProc **free_proc));
-static  int ZnGradientParse _ANSI_ARGS_((ClientData client_data, Tcl_Interp *interp,
+                                            Tcl_FreeProc **free_proc);
+static  int ZnGradientParse(ClientData client_data, Tcl_Interp *interp,
                                          Tk_Window tkwin, Tcl_Obj *ovalue,
-                                         char *widget_rec, int offset));
-static  Tcl_Obj *ZnGradientPrint _ANSI_ARGS_((ClientData client_data, Tk_Window tkwin,
+                                         char *widget_rec, int offset);
+static  Tcl_Obj *ZnGradientPrint(ClientData client_data, Tk_Window tkwin,
                                               char *widget_rec, int offset,
-                                              Tcl_FreeProc **free_proc));
-static  int ZnImageParse _ANSI_ARGS_((ClientData client_data, Tcl_Interp *interp,
+                                              Tcl_FreeProc **free_proc);
+static  int ZnImageParse(ClientData client_data, Tcl_Interp *interp,
                                       Tk_Window tkwin, Tcl_Obj *ovalue,
-                                      char *widget_rec, int offset));
-static  int ZnBitmapParse _ANSI_ARGS_((ClientData client_data, Tcl_Interp *interp,
+                                      char *widget_rec, int offset);
+static  int ZnBitmapParse(ClientData client_data, Tcl_Interp *interp,
                                        Tk_Window tkwin, Tcl_Obj *ovalue,
-                                       char *widget_rec, int offset));
-static  Tcl_Obj *ZnImagePrint _ANSI_ARGS_((ClientData client_data, Tk_Window tkwin,
+                                       char *widget_rec, int offset);
+static  Tcl_Obj *ZnImagePrint(ClientData client_data, Tk_Window tkwin,
                                            char *widget_rec, int offset,
-                                           Tcl_FreeProc **free_proc));
+                                           Tcl_FreeProc **free_proc);
 static  Tk_CustomOption reliefOption = {
   (Tk_OptionParseProc *) ZnReliefParse,
   (Tk_OptionPrintProc *) ZnReliefPrint,
@@ -214,21 +214,21 @@ static  Tk_CustomOption bitmapOption = {
   NULL
 };
 #else
-static  int ZnSetReliefOpt _ANSI_ARGS_((ClientData client_data, Tcl_Interp *interp,
+static  int ZnSetReliefOpt(ClientData client_data, Tcl_Interp *interp,
                                         Tk_Window tkwin, Tcl_Obj **ovalue,
-                                        char *widget_rec, int offset, char *old_val_ptr, int flags));
-static  Tcl_Obj *ZnGetReliefOpt _ANSI_ARGS_((ClientData client_data, Tk_Window tkwin,
-                                             char *widget_rec, int offset));
-static void ZnRestoreReliefOpt _ANSI_ARGS_((ClientData client_data, Tk_Window tkwin,
-                                            char *val_ptr, char *old_val_ptr));
-static  int ZnSetGradientOpt _ANSI_ARGS_((ClientData client_data, Tcl_Interp *interp,
+                                        char *widget_rec, int offset, char *old_val_ptr, int flags);
+static  Tcl_Obj *ZnGetReliefOpt(ClientData client_data, Tk_Window tkwin,
+                                             char *widget_rec, int offset);
+static void ZnRestoreReliefOpt(ClientData client_data, Tk_Window tkwin,
+                                            char *val_ptr, char *old_val_ptr);
+static  int ZnSetGradientOpt(ClientData client_data, Tcl_Interp *interp,
                                           Tk_Window tkwin, Tcl_Obj **ovalue,
-                                          char *widget_rec, int offset, char *old_val_ptr, int flags));
-static  Tcl_Obj *ZnGetGradientOpt _ANSI_ARGS_((ClientData client_data, Tk_Window tkwin,
-                                               char *widget_rec, int offset));
-static  void ZnRestoreGradientOpt _ANSI_ARGS_((ClientData client_data, Tk_Window tkwin,
-                                               char *val_ptr, char *old_val_ptr));
-static  void ZnFreeGradientOpt _ANSI_ARGS_((ClientData client_data, Tk_Window tkwin, char *val_ptr));
+                                          char *widget_rec, int offset, char *old_val_ptr, int flags);
+static  Tcl_Obj *ZnGetGradientOpt(ClientData client_data, Tk_Window tkwin,
+                                               char *widget_rec, int offset);
+static  void ZnRestoreGradientOpt(ClientData client_data, Tk_Window tkwin,
+                                               char *val_ptr, char *old_val_ptr);
+static  void ZnFreeGradientOpt(ClientData client_data, Tk_Window tkwin, char *val_ptr);
 
 static  Tk_ObjCustomOption reliefOption = {
   "znrelief",
@@ -545,27 +545,27 @@ static Tk_OptionSpec option_specs[] = {
 };
 #endif
 
-static void     CmdDeleted _ANSI_ARGS_((ClientData client_data));
-static void     Event _ANSI_ARGS_((ClientData client_data, XEvent *eventPtr));
-static void     Bind _ANSI_ARGS_((ClientData client_data, XEvent *eventPtr));
-static int      FetchSelection _ANSI_ARGS_((ClientData clientData, int offset,
-                                            char *buffer, int maxBytes));
-static void     SelectTo _ANSI_ARGS_((ZnItem item, int field, int index));
-static int      WidgetObjCmd _ANSI_ARGS_((ClientData client_data,
-                                          Tcl_Interp *, int argc, Tcl_Obj *const args[]));
+static void     CmdDeleted(ClientData client_data);
+static void     Event(ClientData client_data, XEvent *eventPtr);
+static void     Bind(ClientData client_data, XEvent *eventPtr);
+static int      FetchSelection(ClientData clientData, int offset,
+                                            char *buffer, int maxBytes);
+static void     SelectTo(ZnItem item, int field, int index);
+static int      WidgetObjCmd(ClientData client_data,
+                                          Tcl_Interp *, int argc, Tcl_Obj *const args[]);
 #ifdef PTK_800
-static int      Configure _ANSI_ARGS_((Tcl_Interp *interp, ZnWInfo *wi,
-                                       int argc, Tcl_Obj *const args[], int flags));
+static int      Configure(Tcl_Interp *interp, ZnWInfo *wi,
+                                       int argc, Tcl_Obj *const args[], int flags);
 #else
-static int      Configure _ANSI_ARGS_((Tcl_Interp *interp, ZnWInfo *wi,
-                                       int argc, Tcl_Obj *const args[]));
+static int      Configure(Tcl_Interp *interp, ZnWInfo *wi,
+                                       int argc, Tcl_Obj *const args[]);
 #endif
-static void     Redisplay _ANSI_ARGS_((ClientData client_data));
-static void     Destroy _ANSI_ARGS_((ZnWInfo *wi));
-static void     InitZinc _ANSI_ARGS_((Tcl_Interp *interp));
-static void     Focus _ANSI_ARGS_((ZnWInfo *wi, ZnBool got_focus));
-static void     Update _ANSI_ARGS_((ZnWInfo     *wi));
-static void     Repair _ANSI_ARGS_((ZnWInfo     *wi));
+static void     Redisplay(ClientData client_data);
+static void     Destroy(ZnWInfo *wi);
+static void     InitZinc(Tcl_Interp *interp);
+static void     Focus(ZnWInfo *wi, ZnBool got_focus);
+static void     Update(ZnWInfo     *wi);
+static void     Repair(ZnWInfo     *wi);
 
 
 #ifdef PTK_800

--- a/generic/tkZinc.c
+++ b/generic/tkZinc.c
@@ -552,13 +552,13 @@ static int      FetchSelection _ANSI_ARGS_((ClientData clientData, int offset,
                                             char *buffer, int maxBytes));
 static void     SelectTo _ANSI_ARGS_((ZnItem item, int field, int index));
 static int      WidgetObjCmd _ANSI_ARGS_((ClientData client_data,
-                                          Tcl_Interp *, int argc, Tcl_Obj *CONST args[]));
+                                          Tcl_Interp *, int argc, Tcl_Obj *const args[]));
 #ifdef PTK_800
 static int      Configure _ANSI_ARGS_((Tcl_Interp *interp, ZnWInfo *wi,
-                                       int argc, Tcl_Obj *CONST args[], int flags));
+                                       int argc, Tcl_Obj *const args[], int flags));
 #else
 static int      Configure _ANSI_ARGS_((Tcl_Interp *interp, ZnWInfo *wi,
-                                       int argc, Tcl_Obj *CONST args[]));
+                                       int argc, Tcl_Obj *const args[]));
 #endif
 static void     Redisplay _ANSI_ARGS_((ClientData client_data));
 static void     Destroy _ANSI_ARGS_((ZnWInfo *wi));
@@ -1339,7 +1339,7 @@ ZincObjCmd(ClientData           client_data,    /* Main window associated with
                                                  * interpreter. */
            Tcl_Interp           *interp,        /* Current interpreter. */
            int                  argc,           /* Number of arguments. */
-           Tcl_Obj      *CONST  args[])         /* Argument strings. */
+           Tcl_Obj      *const  args[])         /* Argument strings. */
 {
   Tk_Window     top_w = (Tk_Window) client_data;
   ZnWInfo       *wi;
@@ -2746,14 +2746,14 @@ ZnItemWithTagOrId(ZnWInfo       *wi,
 static int
 LayoutItems(ZnWInfo     *wi,
             int         argc,
-            Tcl_Obj     *CONST args[])
+            Tcl_Obj     *const args[])
 {
   int           index/*, result*/;
   /*ZnItem              item;*/
 #ifdef PTK_800
   static char *layout_cmd_strings[] =
   #else
-  static CONST char *layout_cmd_strings[] =
+  static const char *layout_cmd_strings[] =
 #endif
   {
     "align", "grid", "position", "scale", "space", NULL
@@ -3116,7 +3116,7 @@ ZnDoItem(Tcl_Interp     *interp,
  */
 static int
 FindArea(ZnWInfo        *wi,
-         Tcl_Obj *CONST args[],
+         Tcl_Obj *const args[],
          Tk_Uid         tag_uid,
          ZnBool         enclosed,
          ZnBool         recursive,
@@ -3188,7 +3188,7 @@ FindArea(ZnWInfo        *wi,
 static int
 FindItems(ZnWInfo       *wi,
           int           argc,
-          Tcl_Obj *CONST args[],
+          Tcl_Obj *const args[],
           Tcl_Obj       *tag,           /* NULL to search or tag to add tag. */
           int           first,          /* First arg to process in args */
           ZnTagSearch   **search_var)
@@ -3201,7 +3201,7 @@ FindItems(ZnWInfo       *wi,
 #ifdef PTK_800
   static char *search_cmd_strings[] =
 #else
-  static CONST char *search_cmd_strings[] =
+  static const char *search_cmd_strings[] =
 #endif
   {
     "above", "ancestors", "atpriority", "below", "closest", "enclosed",
@@ -3684,7 +3684,7 @@ ZnParseCoordList(ZnWInfo        *wi,
 static int
 Contour(ZnWInfo *wi,
         int             argc,
-        Tcl_Obj *CONST  args[],
+        Tcl_Obj *const  args[],
         ZnTagSearch     **search_var)
 {
   ZnPoint       *points;
@@ -3703,7 +3703,7 @@ Contour(ZnWInfo *wi,
 #ifdef PTK_800
   static char *op_strings[] =
 #else
-  static CONST char *op_strings[] =
+  static const char *op_strings[] =
 #endif
   {
     "add", "remove", NULL
@@ -3969,7 +3969,7 @@ Contour(ZnWInfo *wi,
 static int
 Coords(ZnWInfo          *wi,
        int              argc,
-       Tcl_Obj  *CONST  args[],
+       Tcl_Obj  *const  args[],
        ZnTagSearch      **search_var)
 {
   ZnPoint       *points;
@@ -4213,7 +4213,7 @@ static int
 WidgetObjCmd(ClientData         client_data,    /* Information about the widget. */
              Tcl_Interp         *interp,        /* Current interpreter. */
              int                argc,           /* Number of arguments. */
-             Tcl_Obj *CONST     args[])         /* Arguments. */
+             Tcl_Obj *const     args[])         /* Arguments. */
 {
   ZnWInfo       *wi = (ZnWInfo *) client_data;
   int           length, result, cmd_index, index;
@@ -4236,7 +4236,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
 #ifdef PTK_800
   static char *sub_cmd_strings[] =
 #else
-  static CONST char *sub_cmd_strings[] =
+  static const char *sub_cmd_strings[] =
 #endif
   {
     "add", "addtag", "anchorxy", "bbox", "becomes", "bind",
@@ -4267,7 +4267,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
 #ifdef PTK_800
   static char *sel_cmd_strings[] =
 #else
-  static CONST char *sel_cmd_strings[] =
+  static const char *sel_cmd_strings[] =
 #endif
   {
     "adjust", "clear", "from", "item", "to", NULL
@@ -4646,7 +4646,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
           Tcl_SetObjResult(interp, command);
         }
 #else
-        CONST char *command;
+        const char *command;
         command = Tk_GetBinding(interp, wi->binding_table, elem,
                                 Tcl_GetString(args[0]));
         if (command == NULL) {
@@ -6738,7 +6738,7 @@ static int
 Configure(Tcl_Interp            *interp,/* Used for error reporting. */
           ZnWInfo               *wi,    /* Information about widget. */
           int                   argc,   /* Number of valid entries in args. */
-          Tcl_Obj       *CONST  args[], /* Arguments. */
+          Tcl_Obj       *const  args[], /* Arguments. */
           int                   flags)  /* Flags to pass to Tk_ConfigureWidget. */
 {
 #define CONFIG_PROBE(offset) (ISSET(config_specs[offset].specFlags, \
@@ -6752,7 +6752,7 @@ Configure(Tcl_Interp            *interp,/* Used for error reporting. */
 #ifdef PTK
                          (Tcl_Obj **) args, (char *) wi, flags) != TCL_OK)
 #else
-                         (CONST char **) args, (char *) wi, flags|TK_CONFIG_OBJS) != TCL_OK)
+                         (const char **) args, (char *) wi, flags|TK_CONFIG_OBJS) != TCL_OK)
 #endif
   {
     return TCL_ERROR;
@@ -6913,7 +6913,7 @@ Configure(Tcl_Interp            *interp,/* Used for error reporting. */
 #ifdef PTK
       Arg       *args2;
 #else
-      CONST char **args2;
+      const char **args2;
 #endif
 
 #ifdef PTK
@@ -6991,7 +6991,7 @@ static int
 Configure(Tcl_Interp            *interp,/* Used for error reporting. */
           ZnWInfo               *wi,    /* Information about widget. */
           int                   argc,   /* Number of valid entries in args. */
-          Tcl_Obj       *CONST  args[]) /* Arguments. */
+          Tcl_Obj       *const  args[]) /* Arguments. */
 {
   ZnBool                init;
   int                   render, mask, error;

--- a/win/WinPort.c
+++ b/win/WinPort.c
@@ -183,7 +183,7 @@ static int tkpWinRopModes[] = {
  */
 
 typedef BOOL (CALLBACK *WinDrawFunc) _ANSI_ARGS_((HDC dc,
-			    CONST POINT* points, int npoints));
+			    const POINT* points, int npoints));
 
 typedef struct ThreadSpecificData {
     POINT *winPoints;    /* Array of points that is reused. */

--- a/win/WinPort.c
+++ b/win/WinPort.c
@@ -182,8 +182,8 @@ static int tkpWinRopModes[] = {
  * The followng typedef is used to pass Windows GDI drawing functions.
  */
 
-typedef BOOL (CALLBACK *WinDrawFunc) _ANSI_ARGS_((HDC dc,
-			    const POINT* points, int npoints));
+typedef BOOL (CALLBACK *WinDrawFunc)(HDC dc,
+			    const POINT* points, int npoints);
 
 typedef struct ThreadSpecificData {
     POINT *winPoints;    /* Array of points that is reused. */

--- a/zinclib.d/doc/html/ZincExtern_8hpp-source.html
+++ b/zinclib.d/doc/html/ZincExtern_8hpp-source.html
@@ -23,14 +23,14 @@
 00029   <span class="keywordtype">int</span> <a class="code" href="ZincExtern_8hpp.html#a2">ZincObjCmd</a>(ClientData client_data,    <span class="comment">// Main window associated with interpreter.</span>
 00030                  Tcl_Interp *interp,        <span class="comment">// Current interpreter. </span>
 00031                  <span class="keywordtype">int</span>        argc,           <span class="comment">// Number of arguments.</span>
-00032                  Tcl_Obj   *CONST  args[]); <span class="comment">// Argument objects.</span>
+00032                  Tcl_Obj   *const  args[]); <span class="comment">// Argument objects.</span>
 00033 
 00034   <span class="comment">//The TkZinc function that is called by tcl when calling ".zinc fct ..."</span>
 00035   <span class="keyword">typedef</span> int (*WidgetObjCmd)
 <a name="l00036"></a><a class="code" href="ZincExtern_8hpp.html#a0">00036</a>                    (ClientData client_data,   <span class="comment">// Information about the widget.</span>
 00037                     Tcl_Interp *interp,       <span class="comment">// Current interpreter.</span>
 00038                     <span class="keywordtype">int</span>        argc,          <span class="comment">// Number of arguments.</span>
-00039                     Tcl_Obj    *CONST args[]) <span class="comment">// Argument objects.</span>
+00039                     Tcl_Obj    *const args[]) <span class="comment">// Argument objects.</span>
 00040           __attribute__((cdecl));
 00041 
 00042 }

--- a/zinclib.d/doc/html/ZincExtern_8hpp.html
+++ b/zinclib.d/doc/html/ZincExtern_8hpp.html
@@ -13,12 +13,12 @@
 <a href="ZincExtern_8hpp-source.html">Go to the source code of this file.</a><table border=0 cellpadding=0 cellspacing=0>
 <tr><td></td></tr>
 <tr><td colspan=2><br><h2>Typedefs</h2></td></tr>
-<tr><td class="memItemLeft" nowrap align=right valign=top>typedef int(*&nbsp;</td><td class="memItemRight" valign=bottom><a class="el" href="ZincExtern_8hpp.html#a0">WidgetObjCmd</a> )(ClientData client_data, Tcl_Interp *interp, int argc, Tcl_Obj *CONST args[]) __attribute__((cdecl))</td></tr>
+<tr><td class="memItemLeft" nowrap align=right valign=top>typedef int(*&nbsp;</td><td class="memItemRight" valign=bottom><a class="el" href="ZincExtern_8hpp.html#a0">WidgetObjCmd</a> )(ClientData client_data, Tcl_Interp *interp, int argc, Tcl_Obj *const args[]) __attribute__((cdecl))</td></tr>
 
 <tr><td colspan=2><br><h2>Functions</h2></td></tr>
 <tr><td class="memItemLeft" nowrap align=right valign=top>int&nbsp;</td><td class="memItemRight" valign=bottom><a class="el" href="ZincExtern_8hpp.html#a1">Tkzinc_Init</a> (Tcl_Interp *interp)</td></tr>
 
-<tr><td class="memItemLeft" nowrap align=right valign=top>int&nbsp;</td><td class="memItemRight" valign=bottom><a class="el" href="ZincExtern_8hpp.html#a2">ZincObjCmd</a> (ClientData client_data, Tcl_Interp *interp, int argc, Tcl_Obj *CONST args[])</td></tr>
+<tr><td class="memItemLeft" nowrap align=right valign=top>int&nbsp;</td><td class="memItemRight" valign=bottom><a class="el" href="ZincExtern_8hpp.html#a2">ZincObjCmd</a> (ClientData client_data, Tcl_Interp *interp, int argc, Tcl_Obj *const args[])</td></tr>
 
 </table>
 <hr><h2>Typedef Documentation</h2>
@@ -28,7 +28,7 @@
     <td class="mdRow">
       <table cellpadding="0" cellspacing="0" border="0">
         <tr>
-          <td class="md" nowrap valign="top"> typedef int(* <a class="el" href="ZincExtern_8hpp.html#a0">WidgetObjCmd</a>)(ClientData client_data, Tcl_Interp *interp, int argc, Tcl_Obj *CONST args[]) __attribute__((cdecl))
+          <td class="md" nowrap valign="top"> typedef int(* <a class="el" href="ZincExtern_8hpp.html#a0">WidgetObjCmd</a>)(ClientData client_data, Tcl_Interp *interp, int argc, Tcl_Obj *const args[]) __attribute__((cdecl))
       </table>
     </td>
   </tr>
@@ -104,7 +104,7 @@ Contributors: Benoit Peccatte &lt;<a href="mailto:peccatte@intuilab.com">peccatt
         <tr>
           <td></td>
           <td></td>
-          <td class="md" nowrap>Tcl_Obj *CONST&nbsp;</td>
+          <td class="md" nowrap>Tcl_Obj *const&nbsp;</td>
           <td class="mdname" nowrap> <em>args</em>[]</td>
         </tr>
         <tr>

--- a/zinclib.d/doc/html/Zinc_8cpp.html
+++ b/zinclib.d/doc/html/Zinc_8cpp.html
@@ -24,7 +24,7 @@
 <tr><td class="memItemLeft" nowrap align=right valign=top>#define&nbsp;</td><td class="memItemRight" valign=bottom><a class="el" href="Zinc_8cpp.html#a3">z_tcl_call2</a>(fct, msg)</td></tr>
 
 <tr><td colspan=2><br><h2>Functions</h2></td></tr>
-<tr><td class="memItemLeft" nowrap align=right valign=top>int&nbsp;</td><td class="memItemRight" valign=bottom><a class="el" href="Zinc_8cpp.html#a20">tclCallback</a> (ClientData client_data, Tcl_Interp *interp, int argc, Tcl_Obj *CONST args[]) __attribute__((cdecl))</td></tr>
+<tr><td class="memItemLeft" nowrap align=right valign=top>int&nbsp;</td><td class="memItemRight" valign=bottom><a class="el" href="Zinc_8cpp.html#a20">tclCallback</a> (ClientData client_data, Tcl_Interp *interp, int argc, Tcl_Obj *const args[]) __attribute__((cdecl))</td></tr>
 
 <tr><td class="memItemLeft" nowrap align=right valign=top>&nbsp;</td><td class="memItemRight" valign=bottom><a class="el" href="Zinc_8cpp.html#a21">Z_DEFINE_ZOPT</a> (render)</td></tr>
 
@@ -451,7 +451,7 @@ All arguments of the function are Tcl_Obj. To accelerate their call, there is a 
         <tr>
           <td></td>
           <td></td>
-          <td class="md" nowrap>Tcl_Obj *CONST&nbsp;</td>
+          <td class="md" nowrap>Tcl_Obj *const&nbsp;</td>
           <td class="mdname" nowrap> <em>args</em>[]</td>
         </tr>
         <tr>

--- a/zinclib.d/src/Zinc.cpp
+++ b/zinclib.d/src/Zinc.cpp
@@ -61,10 +61,10 @@
 //predeclare private function
 #ifdef _WIN32
 int __cdecl tclCallback (ClientData client_data, Tcl_Interp *interp,
-                  int argc, Tcl_Obj *CONST args[]);
+                  int argc, Tcl_Obj *const args[]);
 #else
 int tclCallback (ClientData client_data, Tcl_Interp *interp,
-                  int argc, Tcl_Obj *CONST args[]) __attribute__((cdecl));
+                  int argc, Tcl_Obj *const args[]) __attribute__((cdecl));
 #endif
 
 /*******************************************************
@@ -1872,7 +1872,7 @@ void Zinc::itemMatrix (ZincItem * item,
  * @param args table of arguments
  */
 int tclCallback (ClientData client_data, Tcl_Interp *interp,
-                  int argc, Tcl_Obj *CONST args[])
+                  int argc, Tcl_Obj *const args[])
 {
   Zinc *zinc = (Zinc*) client_data;
   int cb;

--- a/zinclib.d/src/ZincExtern.hpp
+++ b/zinclib.d/src/ZincExtern.hpp
@@ -51,7 +51,7 @@ extern "C"
   int ZincObjCmd(ClientData client_data,    // Main window associated with interpreter.
                  Tcl_Interp *interp,        // Current interpreter. 
                  int        argc,           // Number of arguments.
-                 Tcl_Obj   *CONST  args[]); // Argument objects.
+                 Tcl_Obj   *const  args[]); // Argument objects.
 
   //The TkZinc function that is called by tcl when calling ".zinc fct ..."
 #ifdef _WIN32
@@ -59,13 +59,13 @@ extern "C"
                            (ClientData client_data,   // Information about the widget.
                             Tcl_Interp *interp,       // Current interpreter.
                             int        argc,          // Number of arguments.
-                            Tcl_Obj    *CONST args[]); // Argument objects.
+                            Tcl_Obj    *const args[]); // Argument objects.
 #else
   typedef int (*WidgetObjCmd)
                    (ClientData client_data,   // Information about the widget.
                     Tcl_Interp *interp,       // Current interpreter.
                     int        argc,          // Number of arguments.
-                    Tcl_Obj    *CONST args[]) // Argument objects.
+                    Tcl_Obj    *const args[]) // Argument objects.
           __attribute__((cdecl));
 #endif
 }


### PR DESCRIPTION
* `CONST` (from tcl.h) was for compatibility with compilers lacking `const`. It is to be deprecated in Tcl 8.7, and removed in Tcl 9.0.
* `_ANSI_ARGS_()` (from tcl.h) was for compatibility with pre-ANSI C compilers. It was deprecated in Tcl 8.6 and will be removed in Tcl 9.0.