### PR TITLE
Avoid signed integer overflow in `ZnListTail`

### DIFF
--- a/generic/List.h
+++ b/generic/List.h
@@ -26,7 +26,7 @@ extern "C" {
 
 
 #define ZnListHead      0
-#define ZnListTail      (~(1 << ((8*sizeof(int)) - 1)))
+#define ZnListTail      (~(1u << ((8*sizeof(int)) - 1)))
 
 
 typedef void    *ZnList;


### PR DESCRIPTION
Example [UBSan `-fsanitize=shift-base`](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#available-checks) error when launching zinc-widget:

```
generic/Item.c:1323:37: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior generic/Item.c:1323:37 in 
```