### PR TITLE
Update for Tcl/Tk 8.6 `const`-ness

### DIFF
--- a/generic/Image.c
+++ b/generic/Image.c
@@ -210,7 +210,7 @@ ZnGetImage(ZnWInfo      *wi,
   ImageBits     *bits;
   ZnBool        for_gl = wi->render>0;
   Image         image;
-  Tk_ImageType  *type;
+  CONST86 Tk_ImageType  *type;
   ClientStruct  cs, *cs_ptr;
 
   /*printf("ZnGetImage: %s\n", image_name);*/

--- a/generic/Types.h
+++ b/generic/Types.h
@@ -67,6 +67,10 @@
 #include <stdio.h>
 
 
+#ifndef CONST86
+#define CONST86
+#endif
+
 /* This EXTERN declaration is needed for Tcl < 8.0.3 */
 #ifndef EXTERN
 # ifdef __cplusplus


### PR DESCRIPTION
Eliminate a compiler warning (one which is now an error as of GCC 14) when building against Tcl/Tk 8.6:

```
./generic/Image.c: In function ‘ZnGetImage’:
./generic/Image.c:245:56: error: passing argument 3 of ‘tkStubsPtr->tk_GetImageMasterData’ from incompatible pointer type [-Wincompatible-pointer-types]
  245 |     if (!Tk_GetImageMasterData(wi->interp, image_name, &type)) {
      |                                                        ^~~~~
      |                                                        |
      |                                                        Tk_ImageType **
./generic/Image.c:245:56: note: expected ‘const Tk_ImageType **’ but argument is of type ‘Tk_ImageType **’
```