### PR TITLE
Update Field.c for C23

### DIFF
--- a/generic/Field.c
+++ b/generic/Field.c
@@ -1615,7 +1615,15 @@ ComputeFieldImageLocation(Field         fptr,
  */
 static void
 FieldsEngine(ZnFieldSet field_set,
-             void       (*cb)())
+             void       (*cb)(ZnWInfo     *wi,
+                              Field       fptr,
+                              ZnBBox      *bbox,
+                              ZnBBox      *pm_bbox,
+                              ZnPoint     *text_pos,
+                              ZnBBox      *text_bbox,
+                              int         cursor,
+                              int         sel_start,
+                              int         sel_stop))
 {
   ZnWInfo       *wi = field_set->item->wi;
   /*int         i;      This one *NEED* to be an int */


### PR DESCRIPTION
Fix compiler errors when using C23 (as done by default as of GCC 15):

```
./generic/Field.c: In function ‘FieldsEngine’:
./generic/Field.c:1744:8: error: too many arguments to function ‘cb’; expected 0, have 9
 1744 |       (*cb)(wi, fptr, &bbox, &pm_bbox,
      |       ~^~~~ ~~
./generic/Field.c: In function ‘DrawFields’:
./generic/Field.c:1958:27: error: passing argument 2 of ‘FieldsEngine’ from incompatible pointer type [-Wincompatible-pointer-types]
 1958 |   FieldsEngine(field_set, DrawField);
      |                           ^~~~~~~~~
      |                           |
      |                           void (*)(ZnWInfo *, struct _FieldStruct *, ZnBBox *, ZnBBox *, ZnPoint *, ZnBBox *, int,  int,  int) {aka void (*)(struct _ZnWInfo *, struct _FieldStruct *, ZnBBox *, ZnBBox *, ZnPoint *, ZnBBox *, int,  int,  int)}
./generic/Field.c:1618:27: note: expected ‘void (*)(void)’ but argument is of type ‘void (*)(ZnWInfo *, struct _FieldStruct *, ZnBBox *, ZnBBox *, ZnPoint *, ZnBBox *, int,  int,  int)’ {aka ‘void (*)(struct _ZnWInfo *, struct _FieldStruct *, ZnBBox *, ZnBBox *, ZnPoint *, ZnBBox *, int,  int,  int)’}
 1618 |              void       (*cb)())
      |              ~~~~~~~~~~~~~^~~~~
./generic/Field.c:1765:1: note: ‘DrawField’ declared here
 1765 | DrawField(ZnWInfo       *wi,
      | ^~~~~~~~~
./generic/Field.c: In function ‘RenderFields’:
./generic/Field.c:2151:27: error: passing argument 2 of ‘FieldsEngine’ from incompatible pointer type [-Wincompatible-pointer-types]
 2151 |   FieldsEngine(field_set, RenderField);
      |                           ^~~~~~~~~~~
      |                           |
      |                           void (*)(ZnWInfo *, struct _FieldStruct *, ZnBBox *, ZnBBox *, ZnPoint *, ZnBBox *, int,  int,  int) {aka void (*)(struct _ZnWInfo *, struct _FieldStruct *, ZnBBox *, ZnBBox *, ZnPoint *, ZnBBox *, int,  int,  int)}
./generic/Field.c:1618:27: note: expected ‘void (*)(void)’ but argument is of type ‘void (*)(ZnWInfo *, struct _FieldStruct *, ZnBBox *, ZnBBox *, ZnPoint *, ZnBBox *, int,  int,  int)’ {aka ‘void (*)(struct _ZnWInfo *, struct _FieldStruct *, ZnBBox *, ZnBBox *, ZnPoint *, ZnBBox *, int,  int,  int)’}
 1618 |              void       (*cb)())
      |              ~~~~~~~~~~~~~^~~~~
./generic/Field.c:1984:1: note: ‘RenderField’ declared here
 1984 | RenderField(ZnWInfo     *wi,
      | ^~~~~~~~~~~
```