### PR TITLE
Partially update OverlapMan.c for C23

### DIFF
--- a/generic/OverlapMan.c
+++ b/generic/OverlapMan.c
@@ -96,8 +96,13 @@ typedef struct _INFOS {
 
 typedef struct _ZINCS {
   void  *rw;
-  void  *(*_next_track)();
-  void  (*_set_label_angle)();
+  void  *(*_next_track)(void *, void *,
+                        int *, int *,
+                        int *, int *,
+                        int *, int *,
+                        int *, int *,
+                        int *, int *);
+  void  (*_set_label_angle)(void *, void *, int, int, char *);
   INFOS *infos;
   int   NBinfos;
   int   NBalloc_infos;


### PR DESCRIPTION
Fix these compiler errors when using C23 (as done by default as of GCC 15):

```
./generic/OverlapMan.c: In function ‘OmRegister’:
./generic/OverlapMan.c:354:21: error: assignment to ‘void * (*)(void)’ from incompatible pointer type ‘void * (*)(void *, void *, int *, int *, int *, int *, int *, int *, int *, int *, int *, int *)’ [-Wincompatible-pointer-types]
  354 |   wr[iw]._next_track= _fnext_track;
      |                     ^
./generic/OverlapMan.c:355:26: error: assignment to ‘void (*)(void)’ from incompatible pointer type ‘void (*)(void *, void *, int,  int,  char *)’ [-Wincompatible-pointer-types]
  355 |   wr[iw]._set_label_angle= _fset_label_angle;
      |                          ^
```