### PR TITLE
tkZinc.c: Fix incompatible function pointer type warnings

### DIFF
--- a/generic/tkZinc.c
+++ b/generic/tkZinc.c
@@ -9460,11 +9460,11 @@ InitZinc(Tcl_Interp *interp) {
   ZnTesselator.tess = gluNewTess();
   ZnTesselator.combine_list = NULL;
         ZnTesselator.combine_length = 0;
-  gluTessCallback(ZnTesselator.tess, GLU_TESS_BEGIN_DATA, ZnTessBegin);
-  gluTessCallback(ZnTesselator.tess, GLU_TESS_VERTEX_DATA, ZnTessVertex);
-  gluTessCallback(ZnTesselator.tess, GLU_TESS_END_DATA, ZnTessEnd);
-  gluTessCallback(ZnTesselator.tess, GLU_TESS_COMBINE_DATA, ZnTessCombine);
-  gluTessCallback(ZnTesselator.tess, GLU_TESS_ERROR_DATA, ZnTessError);
+  gluTessCallback(ZnTesselator.tess, GLU_TESS_BEGIN_DATA, (_GLUfuncptr)ZnTessBegin);
+  gluTessCallback(ZnTesselator.tess, GLU_TESS_VERTEX_DATA, (_GLUfuncptr)ZnTessVertex);
+  gluTessCallback(ZnTesselator.tess, GLU_TESS_END_DATA, (_GLUfuncptr)ZnTessEnd);
+  gluTessCallback(ZnTesselator.tess, GLU_TESS_COMBINE_DATA, (_GLUfuncptr)ZnTessCombine);
+  gluTessCallback(ZnTesselator.tess, GLU_TESS_ERROR_DATA, (_GLUfuncptr)ZnTessError);
   gluTessNormal(ZnTesselator.tess, 0.0, 0.0, -1.0);
 
   /*


### PR DESCRIPTION
Fix compiler warnings (which are considered errors as of GCC 14), as previously reported at https://github.com/asb-capfan/TkZinc/issues/14#issuecomment-2566550933
```
./generic/tkZinc.c: In function ‘InitZinc’:
./generic/tkZinc.c:9463:59: error: passing argument 3 of ‘gluTessCallback’ from incompatible pointer type [-Wincompatible-pointer-types]
 9463 |   gluTessCallback(ZnTesselator.tess, GLU_TESS_BEGIN_DATA, ZnTessBegin);
      |                                                           ^~~~~~~~~~~
      |                                                           |
      |                                                           void (*)(GLenum,  void *) {aka void (*)(unsigned int,  void *)}
In file included from /usr/include/GL/glew.h:1219,
                 from ./generic/tkZinc.c:34:
/usr/include/GL/glu.h:336:87: note: expected ‘_GLUfuncptr’ {aka ‘void (*)(void)’} but argument is of type ‘void (*)(GLenum,  void *)’ {aka ‘void (*)(unsigned int,  void *)’}
  336 | GLAPI void GLAPIENTRY gluTessCallback (GLUtesselator* tess, GLenum which, _GLUfuncptr CallBackFunc);
      |                                                                           ~~~~~~~~~~~~^~~~~~~~~~~~
./generic/tkZinc.c:9283:1: note: ‘ZnTessBegin’ declared here
 9283 | ZnTessBegin(GLenum      type,
      | ^~~~~~~~~~~
/usr/include/GL/glu.h:283:27: note: ‘_GLUfuncptr’ declared here
  283 | typedef void (GLAPIENTRYP _GLUfuncptr)(void);
      |                           ^~~~~~~~~~~
./generic/tkZinc.c:9464:60: error: passing argument 3 of ‘gluTessCallback’ from incompatible pointer type [-Wincompatible-pointer-types]
 9464 |   gluTessCallback(ZnTesselator.tess, GLU_TESS_VERTEX_DATA, ZnTessVertex);
      |                                                            ^~~~~~~~~~~~
      |                                                            |
      |                                                            void (*)(void *, void *)
/usr/include/GL/glu.h:336:87: note: expected ‘_GLUfuncptr’ {aka ‘void (*)(void)’} but argument is of type ‘void (*)(void *, void *)’
  336 | GLAPI void GLAPIENTRY gluTessCallback (GLUtesselator* tess, GLenum which, _GLUfuncptr CallBackFunc);
      |                                                                           ~~~~~~~~~~~~^~~~~~~~~~~~
./generic/tkZinc.c:9310:1: note: ‘ZnTessVertex’ declared here
 9310 | ZnTessVertex(void       *vertex_data,
      | ^~~~~~~~~~~~
/usr/include/GL/glu.h:283:27: note: ‘_GLUfuncptr’ declared here
  283 | typedef void (GLAPIENTRYP _GLUfuncptr)(void);
      |                           ^~~~~~~~~~~
./generic/tkZinc.c:9465:57: error: passing argument 3 of ‘gluTessCallback’ from incompatible pointer type [-Wincompatible-pointer-types]
 9465 |   gluTessCallback(ZnTesselator.tess, GLU_TESS_END_DATA, ZnTessEnd);
      |                                                         ^~~~~~~~~
      |                                                         |
      |                                                         void (*)(void *)
/usr/include/GL/glu.h:336:87: note: expected ‘_GLUfuncptr’ {aka ‘void (*)(void)’} but argument is of type ‘void (*)(void *)’
  336 | GLAPI void GLAPIENTRY gluTessCallback (GLUtesselator* tess, GLenum which, _GLUfuncptr CallBackFunc);
      |                                                                           ~~~~~~~~~~~~^~~~~~~~~~~~
./generic/tkZinc.c:9338:1: note: ‘ZnTessEnd’ declared here
 9338 | ZnTessEnd(void  *data)
      | ^~~~~~~~~
/usr/include/GL/glu.h:283:27: note: ‘_GLUfuncptr’ declared here
  283 | typedef void (GLAPIENTRYP _GLUfuncptr)(void);
      |                           ^~~~~~~~~~~
./generic/tkZinc.c:9466:61: error: passing argument 3 of ‘gluTessCallback’ from incompatible pointer type [-Wincompatible-pointer-types]
 9466 |   gluTessCallback(ZnTesselator.tess, GLU_TESS_COMBINE_DATA, ZnTessCombine);
      |                                                             ^~~~~~~~~~~~~
      |                                                             |
      |                                                             void (*)(GLdouble *, void **, GLfloat *, void **, void *) {aka void (*)(double *, void **, float *, void **, void *)}
/usr/include/GL/glu.h:336:87: note: expected ‘_GLUfuncptr’ {aka ‘void (*)(void)’} but argument is of type ‘void (*)(GLdouble *, void **, GLfloat *, void **, void *)’ {aka ‘void (*)(double *, void **, float *, void **, void *)’}
  336 | GLAPI void GLAPIENTRY gluTessCallback (GLUtesselator* tess, GLenum which, _GLUfuncptr CallBackFunc);
      |                                                                           ~~~~~~~~~~~~^~~~~~~~~~~~
./generic/tkZinc.c:9367:1: note: ‘ZnTessCombine’ declared here
 9367 | ZnTessCombine(GLdouble  coords[3],
      | ^~~~~~~~~~~~~
/usr/include/GL/glu.h:283:27: note: ‘_GLUfuncptr’ declared here
  283 | typedef void (GLAPIENTRYP _GLUfuncptr)(void);
      |                           ^~~~~~~~~~~
./generic/tkZinc.c:9467:59: error: passing argument 3 of ‘gluTessCallback’ from incompatible pointer type [-Wincompatible-pointer-types]
 9467 |   gluTessCallback(ZnTesselator.tess, GLU_TESS_ERROR_DATA, ZnTessError);
      |                                                           ^~~~~~~~~~~
      |                                                           |
      |                                                           void (*)(GLenum * (*)(void), void *) {aka void (*)(unsigned int * (*)(void), void *)}
/usr/include/GL/glu.h:336:87: note: expected ‘_GLUfuncptr’ {aka ‘void (*)(void)’} but argument is of type ‘void (*)(GLenum * (*)(void), void *)’ {aka ‘void (*)(unsigned int * (*)(void), void *)’}
  336 | GLAPI void GLAPIENTRY gluTessCallback (GLUtesselator* tess, GLenum which, _GLUfuncptr CallBackFunc);
      |                                                                           ~~~~~~~~~~~~^~~~~~~~~~~~
./generic/tkZinc.c:9387:1: note: ‘ZnTessError’ declared here
 9387 | ZnTessError(GLenum      errno,
      | ^~~~~~~~~~~
/usr/include/GL/glu.h:283:27: note: ‘_GLUfuncptr’ declared here
  283 | typedef void (GLAPIENTRYP _GLUfuncptr)(void);
      |                           ^~~~~~~~~~~
```