### PR TITLE
Accommodate TIP 647

### DIFF
--- a/generic/PostScript.c
+++ b/generic/PostScript.c
@@ -303,7 +303,7 @@ ZnPostScriptCmd(ZnWInfo        *wi,
   ps_info.prolog = 1;
   Tcl_InitHashTable(&ps_info.fontTable, TCL_STRING_KEYS);
   result = Tk_ConfigureWidget(wi->interp, wi->win, config_specs,
-                              argc-2, (const char **) argv+2,
+                              argc-2, (void *) argv+2,
                               (char *) &ps_info,
                               TK_CONFIG_ARGV_ONLY|TK_CONFIG_OBJS);
   if (result != TCL_OK) {


### PR DESCRIPTION
This is the change suggested by https://core.tcl-lang.org/tips/doc/trunk/tip/647.md for compatibility with both Tk 8 and 9. It likely also fixes the Perl/Tk build error originally reported at https://github.com/asb-capfan/TkZinc/issues/14#issue-2716368165

Compiler error (instead of warning since GCC 14) when building with Tcl/Tk 9.0:
```
./generic/PostScript.c: In function ‘ZnPostScriptCmd’:
./generic/PostScript.c:306:59: error: passing argument 5 of ‘tkStubsPtr->tk_ConfigureWidget’ from incompatible pointer type [-Wincompatible-pointer-types]
  306 |                               argc-2, (const char **) argv+2,
      |                                       ~~~~~~~~~~~~~~~~~~~~^~
      |                                                           |
      |                                                           const char **
./generic/PostScript.c:306:59: note: expected ‘Tcl_Obj * const*’ but argument is of type ‘const char **’
```