### PR TITLE
Accommodate TIP 528

### DIFF
--- a/generic/Types.h
+++ b/generic/Types.h
@@ -71,6 +71,10 @@
 #define CONST86
 #endif
 
+#ifndef Tk_Offset
+#define Tk_Offset offsetof
+#endif
+
 /* This EXTERN declaration is needed for Tcl < 8.0.3 */
 #ifndef EXTERN
 # ifdef __cplusplus


### PR DESCRIPTION
The `Tk_Offset` macro was deprecated by https://core.tcl-lang.org/tips/doc/trunk/tip/528.md in favor of `offsetof`.

Rather than replacing all instances of `Tk_Offset`, this PR instead makes `Tk_Offset` available when building with newer Tk.

Example compiler error when building with Tk 9.0:
```
./generic/PostScript.c:122:8: error: implicit declaration of function ‘Tk_Offset’ [-Wimplicit-function-declaration]
  122 |    "", Tk_Offset(TkPostscriptInfo, colorVar), 0, NULL},
      |        ^~~~~~~~~
./generic/PostScript.c:122:18: error: expected expression before ‘TkPostscriptInfo’
  122 |    "", Tk_Offset(TkPostscriptInfo, colorVar), 0, NULL},
      |                  ^~~~~~~~~~~~~~~~
```