### PR TITLE
Remove `rcs_id[]` and `compile_id[]`

### DIFF
--- a/generic/List.c
+++ b/generic/List.c
@@ -68,8 +68,6 @@
  *
  **********************************************************************************
  */
-static const char rcs_id[]="$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 
 #define MAX_CHUNCK_SIZE         1024
 

--- a/generic/tkZinc.c
+++ b/generic/tkZinc.c
@@ -25,8 +25,6 @@
  *
  */
 
-static const char rcs_id[]="$Id$";
-static const char compile_id[]="$Compile: " __FILE__ " " __DATE__ " " __TIME__ " $";
 static const char * const zinc_version = "zinc-version-" PACKAGE_VERSION;
 
 


### PR DESCRIPTION
For same reasons as #9 