### PR TITLE
Cast `NULL` sentinels to `Tcl_AppendResult()`

### DIFF
--- a/generic/Arc.c
+++ b/generic/Arc.c
@@ -173,7 +173,7 @@ Init(ZnItem             item,
   arc->grad_geo = NULL;
   
   if (*argc < 1) {
-    Tcl_AppendResult(wi->interp, " arc coords expected", NULL);
+    Tcl_AppendResult(wi->interp, " arc coords expected", (char *) NULL);
     return TCL_ERROR;
   }
   if (ZnParseCoordList(wi, (*args)[0], &points,
@@ -181,7 +181,7 @@ Init(ZnItem             item,
     return TCL_ERROR;
   }
   if (num_points != 2) {
-    Tcl_AppendResult(wi->interp, " malformed arc coords", NULL);
+    Tcl_AppendResult(wi->interp, " malformed arc coords", (char *) NULL);
     return TCL_ERROR;
   };
   arc->coords[0] = points[0];
@@ -1120,13 +1120,13 @@ Coords(ZnItem           item,
 
   if ((cmd == ZN_COORDS_ADD) || (cmd == ZN_COORDS_ADD_LAST) || (cmd == ZN_COORDS_REMOVE)) {
     Tcl_AppendResult(item->wi->interp,
-                     " arcs can't add or remove vertices", NULL);
+                     " arcs can't add or remove vertices", (char *) NULL);
     return TCL_ERROR;
   }
   else if (cmd == ZN_COORDS_REPLACE_ALL) {
     if (*num_pts != 2) {
       Tcl_AppendResult(item->wi->interp,
-                       " coords command need 2 points on arcs", NULL);
+                       " coords command need 2 points on arcs", (char *) NULL);
       return TCL_ERROR;
     }
     arc->coords[0] = (*pts)[0];
@@ -1136,7 +1136,7 @@ Coords(ZnItem           item,
   else if (cmd == ZN_COORDS_REPLACE) {
     if (*num_pts < 1) {
       Tcl_AppendResult(item->wi->interp,
-                       " coords command need at least 1 point", NULL);
+                       " coords command need at least 1 point", (char *) NULL);
       return TCL_ERROR;
     }
     if (index < 0) {
@@ -1145,7 +1145,7 @@ Coords(ZnItem           item,
     if ((index < 0) || (index > 1)) {
     range_err:
       Tcl_AppendResult(item->wi->interp,
-                       " incorrect coord index, should be between -2 and 1", NULL);
+                       " incorrect coord index, should be between -2 and 1", (char *) NULL);
       return TCL_ERROR;
     }
     arc->coords[index] = (*pts)[0];
@@ -1218,19 +1218,19 @@ PostScript(ZnItem item,
     p = ZnListArray(arc->render_shape);
     num_points = ZnListSize(arc->render_shape);
     sprintf(path, "%.15g %.15g moveto ", p[0].x, p[0].y);
-    Tcl_AppendResult(wi->interp, path, NULL);
+    Tcl_AppendResult(wi->interp, path, (char *) NULL);
     for (i = 0; i < num_points; i++) {
       sprintf(path, "%.15g %.15g lineto ", p[i].x, p[i].y);
-      Tcl_AppendResult(wi->interp, path, NULL);
+      Tcl_AppendResult(wi->interp, path, (char *) NULL);
     }
-    Tcl_AppendResult(wi->interp, "closepath\n", NULL);
+    Tcl_AppendResult(wi->interp, "closepath\n", (char *) NULL);
   }
   else {
     sprintf(path,
             "matrix currentmatrix\n%.15g %.15g translate %.15g %.15g scale 1 0 moveto 0 0 1 0 360 arc\nsetmatrix\n",
             (arc->corner.x + arc->orig.x) / 2.0, (arc->corner.y + arc->orig.y) / 2.0,
             (arc->corner.x - arc->orig.x) / 2.0, (arc->corner.y - arc->orig.y) / 2.0);
-    Tcl_AppendResult(wi->interp, path, NULL);
+    Tcl_AppendResult(wi->interp, path, (char *) NULL);
   }
   
   /*
@@ -1238,7 +1238,7 @@ PostScript(ZnItem item,
    */
   if (ISSET(arc->flags, FILLED_BIT)) {
     if (arc->line_width) {
-      Tcl_AppendResult(wi->interp, "gsave\n", NULL);
+      Tcl_AppendResult(wi->interp, "gsave\n", (char *) NULL);
     }
     if (!ZnGradientFlat(arc->fill_color)) {
       if (ZnPostscriptGradient(wi->interp, wi->ps_info, arc->fill_color,
@@ -1255,7 +1255,7 @@ PostScript(ZnItem item,
                                ZnGetGradientColor(arc->fill_color, 0.0, NULL)) != TCL_OK) {
           return TCL_ERROR;
         }
-        Tcl_AppendResult(wi->interp, "clip ", NULL);
+        Tcl_AppendResult(wi->interp, "clip ", (char *) NULL);
         if (Tk_PostscriptStipple(wi->interp, wi->win, wi->ps_info,
                                  ZnImagePixmap(arc->tile, wi->win)) != TCL_OK) {
           return TCL_ERROR;
@@ -1267,10 +1267,10 @@ PostScript(ZnItem item,
                              ZnGetGradientColor(arc->fill_color, 0.0, NULL)) != TCL_OK) {
         return TCL_ERROR;
       }
-      Tcl_AppendResult(wi->interp, "fill\n", NULL);
+      Tcl_AppendResult(wi->interp, "fill\n", (char *) NULL);
     }
     if (arc->line_width) {
-      Tcl_AppendResult(wi->interp, "grestore\n", NULL);
+      Tcl_AppendResult(wi->interp, "grestore\n", (char *) NULL);
     }
   }
 
@@ -1278,7 +1278,7 @@ PostScript(ZnItem item,
    * Then emit code code to stroke the outline.
    */
   if (arc->line_width) {
-    Tcl_AppendResult(wi->interp, "0 setlinejoin 2 setlinecap\n", NULL);
+    Tcl_AppendResult(wi->interp, "0 setlinejoin 2 setlinecap\n", (char *) NULL);
     if (ZnPostscriptOutline(wi->interp, wi->ps_info, wi->win,
                             arc->line_width, arc->line_style,
                             arc->line_color, arc->line_pattern) != TCL_OK) {

--- a/generic/Attrs.c
+++ b/generic/Attrs.c
@@ -106,7 +106,7 @@ ZnGetRelief(ZnWInfo             *wi,
                      RELIEF_ROUND_RIDGE_SPEC, ", ",
                      RELIEF_SUNKEN_RULE_SPEC, ", ",
                      RELIEF_RAISED_RULE_SPEC,
-                     NULL);
+                     (char *) NULL);
     return TCL_ERROR;
   }
   if (!wi->render) {
@@ -187,7 +187,7 @@ ZnGetBorder(ZnWInfo     *wi,
                      BORDER_OBLIQUE_SPEC, " or ",
                      BORDER_CONTOUR_SPEC, ", ",
                      NO_BORDER_SPEC, " alone",
-                     NULL);
+                     (char *) NULL);
     return TCL_ERROR;
   }
   for (j = 0; j < largc; j++) {
@@ -330,7 +330,7 @@ ZnGetLineShape(ZnWInfo          *wi,
                      LEFT_CORNER_SPEC, ", ",
                      DOUBLE_RIGHT_CORNER_SPEC, ", ",
                      DOUBLE_LEFT_CORNER_SPEC,
-                     NULL);
+                     (char *) NULL);
     return TCL_ERROR;
   }
   return TCL_OK;
@@ -393,7 +393,7 @@ ZnGetLineStyle(ZnWInfo          *wi,
                      DASHED_SPEC, ", ",
                      DOTTED_SPEC, ", ",
                      MIXED_SPEC,
-                     NULL);
+                     (char *) NULL);
     return TCL_ERROR;         
   }
   return TCL_OK;
@@ -455,7 +455,7 @@ ZnGetLeaderAnchors(ZnWInfo              *wi,
       if (num_tok != 1) {
       la_error:
         Tcl_AppendResult(wi->interp, " incorrect leader anchors \"",
-                         name, "\"", NULL);
+                         name, "\"", (char *) NULL);
         return TCL_ERROR;
       }
       anchors[anchor_index+1] = -1;
@@ -644,7 +644,7 @@ ZnLFCreate(Tcl_Interp   *interp,
     }
     else {
       Tcl_AppendResult(interp, "too many fields in label format: \"",
-                       format_str, "\"", NULL);
+                       format_str, "\"", (char *) NULL);
       return NULL;
     }
   }
@@ -666,7 +666,7 @@ ZnLFCreate(Tcl_Interp   *interp,
     if ((ptr == next_ptr) || (*next_ptr != 'x')) {
     lf_error_syn:
       Tcl_AppendResult(interp, "invalid label format specification \"",
-                       ptr, "\"", NULL);
+                       ptr, "\"", (char *) NULL);
     lf_error:
       Tcl_DeleteHashEntry(entry);
       ZnListFree(fields);
@@ -737,12 +737,12 @@ ZnLFCreate(Tcl_Interp   *interp,
     else if (!*ptr || (field_index != 0)) {
       /* An incomplete field spec is an error if there are several fields. */
       Tcl_AppendResult(interp, "incomplete field in label format: \"",
-                       ptr-index, "\"", NULL);
+                       ptr-index, "\"", (char *) NULL);
       goto lf_error;            
     }
     if (field_index >= num_fields) {
       Tcl_AppendResult(interp, "too many fields in label format: \"",
-                       format_str, "\"", NULL);
+                       format_str, "\"", (char *) NULL);
       goto lf_error;
     }
     field_struct.width_spec = (short) width;
@@ -931,7 +931,7 @@ ZnLineEndCreate(Tcl_Interp      *interp,
   }
   else {
     Tcl_AppendResult(interp, "incorrect line end spec: \"",
-                     line_end_str, "\", should be: shapeA shapeB shapeC", NULL);
+                     line_end_str, "\", should be: shapeA shapeB shapeC", (char *) NULL);
     return NULL;
   }
 }
@@ -1007,7 +1007,7 @@ ZnGetFillRule(ZnWInfo    *wi,
                      FILL_RULE_POSITIVE_SPEC, ", ",
                      FILL_RULE_NEGATIVE_SPEC, ", ",
                      FILL_RULE_ABS_GEQ_2_SPEC,
-                     NULL);
+                     (char *) NULL);
     return TCL_ERROR;
   }
   return TCL_OK;
@@ -1074,7 +1074,7 @@ ZnGetAutoAlign(ZnWInfo          *wi,
   else {
   aa_error:
     Tcl_AppendResult(wi->interp, "invalid auto alignment specification \"", name,
-                     "\" should be - or a triple of lcr", NULL);
+                     "\" should be - or a triple of lcr", (char *) NULL);
     return TCL_ERROR;
   }
   return TCL_OK;

--- a/generic/Color.c
+++ b/generic/Color.c
@@ -365,20 +365,20 @@ ZnNameGradient(Tcl_Interp       *interp,
    */
   if (XParseColor(Tk_Display(tkwin), Tk_Colormap(tkwin), name, &color)) {
     Tcl_AppendResult(interp, "gradient name \"", name,
-                     "\", is a color name", NULL);
+                     "\", is a color name", (char *) NULL);
     return False;
   }
   grad = ZnGetGradient(interp, tkwin, grad_descr);
   if (!grad) {
     Tcl_AppendResult(interp, "gradient specification \"", grad_descr,
-                     "\", is invalid", NULL);
+                     "\", is invalid", (char *) NULL);
     return False;
   }
   hash = Tcl_CreateHashEntry(&gradient_table, Tk_GetUid(name), &new);
   if (!new) {
     ZnFreeGradient(grad);
     Tcl_AppendResult(interp, "gradient name \"", name,
-                     "\", is already in use", NULL);
+                     "\", is already in use", (char *) NULL);
     return False;
   }
   else {
@@ -873,7 +873,7 @@ ZnGetGradient(Tcl_Interp        *interp,
   }
   if (num_colors == 0) {
     Tcl_AppendResult(interp, "gradient should have at least one color \"",
-                     desc, "\",", NULL);
+                     desc, "\",", (char *) NULL);
   grad_err1:
     Tcl_DeleteHashEntry(hash);
     /*printf("ZnGetGradient error : %s\n", desc);*/
@@ -897,7 +897,7 @@ ZnGetGradient(Tcl_Interp        *interp,
       if ((num_coords != 1) && (num_coords != 4)) {
       grad_err3:
         Tcl_AppendResult(interp, "invalid gradient parameter \"",
-                         desc, "\",", NULL);
+                         desc, "\",", (char *) NULL);
         goto grad_err1;
       }
       angle = (int) coords[0];
@@ -928,7 +928,7 @@ ZnGetGradient(Tcl_Interp        *interp,
     }
     else {
       Tcl_AppendResult(interp, "invalid gradient type \"",
-                       desc, "\"", NULL);
+                       desc, "\"", (char *) NULL);
       goto grad_err1;
     }
     scan_ptr = next_ptr + 1;
@@ -1017,7 +1017,7 @@ ZnGetGradient(Tcl_Interp        *interp,
     }
     if (size > (SEGMENT_SIZE-1)) {
       Tcl_AppendResult(interp, "color name too long in gradient \"",
-                       desc, "\",", NULL);
+                       desc, "\",", (char *) NULL);
     grad_err2:
       for (j = 0; j < i; j++) {
         Tk_FreeColor(grad->colors_in[j].rgb);
@@ -1049,7 +1049,7 @@ ZnGetGradient(Tcl_Interp        *interp,
     nspace = strspn(scan_ptr, " \t");
     if ((scan_ptr[nspace] != 0) && (scan_ptr+nspace != next_ptr)) {
       Tcl_AppendResult(interp, "incorrect color description in gradient \"",
-                       desc, "\",", NULL);
+                       desc, "\",", (char *) NULL);
       goto grad_err2;
     }
     
@@ -1060,7 +1060,7 @@ ZnGetGradient(Tcl_Interp        *interp,
     grad->colors_in[i].rgb = Tk_GetColor(interp, tkwin, Tk_GetUid(segment));
     if (grad->colors_in[i].rgb == NULL) {
       Tcl_AppendResult(interp, "incorrect color value in gradient \"",
-                       desc, "\",", NULL);
+                       desc, "\",", (char *) NULL);
       goto grad_err2;
     }
     if (color_ptr) {
@@ -1077,7 +1077,7 @@ ZnGetGradient(Tcl_Interp        *interp,
         ((grad->colors_in[i].position > 100) ||
          (grad->colors_in[i].position < grad->colors_in[i-1].position))) {
       Tcl_AppendResult(interp, "incorrect color position in gradient \"",
-                       desc, "\",", NULL);
+                       desc, "\",", (char *) NULL);
       goto grad_err2;
     }
     if (grad->colors_in[i].control > 100) {

--- a/generic/Curve.c
+++ b/generic/Curve.c
@@ -191,7 +191,7 @@ Init(ZnItem             item,
   item->priority = 1;
 
   if (*argc < 1) {
-    Tcl_AppendResult(wi->interp, " curve coords expected", NULL);
+    Tcl_AppendResult(wi->interp, " curve coords expected", (char *) NULL);
     return TCL_ERROR;
   }
   if (ZnParseCoordList(wi, (*args)[0], &points,
@@ -226,7 +226,7 @@ Init(ZnItem             item,
         default:
         contr_err:
           ZnFree(controls);
-          Tcl_AppendResult(wi->interp, " curve coords expected", NULL);
+          Tcl_AppendResult(wi->interp, " curve coords expected", (char *) NULL);
           return TCL_ERROR;
         }
       }
@@ -1605,17 +1605,17 @@ PostScript(ZnItem item,
    * Put all contours in an array on the stack
    */
   if (ISSET(cv->flags, FILLED_BIT) || cv->line_width) {
-    Tcl_AppendResult(wi->interp, "newpath ", NULL);
+    Tcl_AppendResult(wi->interp, "newpath ", (char *) NULL);
     for (i = 0; i < num_contours; i++, contours++) {
       num_points = contours->num_points;
       points = contours->points;
       sprintf(path, "%.15g %.15g moveto\n", points[0].x, points[0].y);
-      Tcl_AppendResult(wi->interp, path, NULL);
+      Tcl_AppendResult(wi->interp, path, (char *) NULL);
       for (j = 1; j < num_points; j++) {
         sprintf(path, "%.15g %.15g lineto ", points[j].x, points[j].y);
-        Tcl_AppendResult(wi->interp, path, NULL);
+        Tcl_AppendResult(wi->interp, path, (char *) NULL);
         if (((j+1) % 5) == 0) {
-          Tcl_AppendResult(wi->interp, "\n", NULL);
+          Tcl_AppendResult(wi->interp, "\n", (char *) NULL);
         }
       }
     }
@@ -1626,7 +1626,7 @@ PostScript(ZnItem item,
    */
   if (ISSET(cv->flags, FILLED_BIT)) {
     if (cv->line_width) {
-      Tcl_AppendResult(wi->interp, "gsave\n", NULL);
+      Tcl_AppendResult(wi->interp, "gsave\n", (char *) NULL);
     }
     if (!ZnGradientFlat(cv->fill_color)) {
       if (ZnPostscriptGradient(wi->interp, wi->ps_info, cv->fill_color,
@@ -1643,7 +1643,7 @@ PostScript(ZnItem item,
                                ZnGetGradientColor(cv->fill_color, 0.0, NULL)) != TCL_OK) {
           return TCL_ERROR;
         }
-        Tcl_AppendResult(wi->interp, "clip ", NULL);
+        Tcl_AppendResult(wi->interp, "clip ", (char *) NULL);
         if (Tk_PostscriptStipple(wi->interp, wi->win, wi->ps_info,
                                  ZnImagePixmap(cv->tile, wi->win)) != TCL_OK) {
           return TCL_ERROR;
@@ -1655,10 +1655,10 @@ PostScript(ZnItem item,
                              ZnGetGradientColor(cv->fill_color, 0.0, NULL)) != TCL_OK) {
         return TCL_ERROR;
       }
-      Tcl_AppendResult(wi->interp, "fill\n", NULL);
+      Tcl_AppendResult(wi->interp, "fill\n", (char *) NULL);
     }
     if (cv->line_width) {
-      Tcl_AppendResult(wi->interp, "grestore\n", NULL);
+      Tcl_AppendResult(wi->interp, "grestore\n", (char *) NULL);
     }
   }
 
@@ -1670,7 +1670,7 @@ PostScript(ZnItem item,
       /* TODO No support yet */
     }
     else {
-      Tcl_AppendResult(wi->interp, "0 setlinejoin 2 setlinecap\n", NULL);
+      Tcl_AppendResult(wi->interp, "0 setlinejoin 2 setlinecap\n", (char *) NULL);
       if (ZnPostscriptOutline(wi->interp, wi->ps_info, wi->win,
                               cv->line_width, cv->line_style,
                               cv->line_color, cv->line_pattern) != TCL_OK) {
@@ -1783,7 +1783,7 @@ Coords(ZnItem           item,
   }
   if ((contour < 0) || ((unsigned int) contour >= cv->shape.num_contours)) {
     Tcl_AppendResult(item->wi->interp,
-                     " curve contour index out of range", NULL);
+                     " curve contour index out of range", (char *) NULL);
     return TCL_ERROR;
   }
   if (cv->shape.num_contours != 0) {
@@ -1818,7 +1818,7 @@ Coords(ZnItem           item,
     else {
       if (*num_pts == 0) {
         Tcl_AppendResult(item->wi->interp,
-                         " coords replace command need at least 1 point on curves", NULL);
+                         " coords replace command need at least 1 point on curves", (char *) NULL);
         return TCL_ERROR;
       }
       if (index < 0) {
@@ -1826,7 +1826,7 @@ Coords(ZnItem           item,
       }
       if ((index < 0) || ((unsigned int) index >= c->num_points)) {
       range_err:
-        Tcl_AppendResult(item->wi->interp, " coord index out of range", NULL);
+        Tcl_AppendResult(item->wi->interp, " coord index out of range", (char *) NULL);
         return TCL_ERROR;
       }
       /*printf("--->%g@%g\n", (*pts)[0].x, (*pts)[0].y);*/
@@ -1849,14 +1849,14 @@ Coords(ZnItem           item,
             num_controls = 0;
             if (!index) {
             control_first:
-              Tcl_AppendResult(item->wi->interp, " the first point must not be a control", NULL);
+              Tcl_AppendResult(item->wi->interp, " the first point must not be a control", (char *) NULL);
               return TCL_ERROR;       
             }
             else if ((unsigned int) index == c->num_points-1) {
               if (ISCLEAR(cv->flags, CLOSED_BIT) &&
                   (cv->shape.num_contours == 1)) {
               control_last:
-                Tcl_AppendResult(item->wi->interp, " the last point must not be a control", NULL);
+                Tcl_AppendResult(item->wi->interp, " the last point must not be a control", (char *) NULL);
                 return TCL_ERROR;             
               }
             }
@@ -1866,7 +1866,7 @@ Coords(ZnItem           item,
             for (j = index+1; c->controls[j] && (j < c->num_points); j++, num_controls++);
             if (num_controls > 1) {
             control_err:
-              Tcl_AppendResult(item->wi->interp, " too many consecutive control points in a curve", NULL);
+              Tcl_AppendResult(item->wi->interp, " too many consecutive control points in a curve", (char *) NULL);
               return TCL_ERROR;
             }
           }
@@ -2063,7 +2063,7 @@ Contour(ZnItem  item,
     }
     if (index < 0) {
     contour_err:
-      Tcl_AppendResult(item->wi->interp, " contour index out of range", NULL);
+      Tcl_AppendResult(item->wi->interp, " contour index out of range", (char *) NULL);
       return TCL_ERROR;
     }
     num_contours = cv->shape.num_contours + poly->num_contours;

--- a/generic/Field.c
+++ b/generic/Field.c
@@ -937,7 +937,7 @@ ConfigureField(ZnFieldSet       fs,
 #endif
 
   if ((field < 0) || ((unsigned int) field >= fs->num_fields)) {
-    Tcl_AppendResult(wi->interp, "invalid field index", NULL);
+    Tcl_AppendResult(wi->interp, "invalid field index", (char *) NULL);
     return TCL_ERROR;
   }
   
@@ -1046,7 +1046,7 @@ QueryField(ZnFieldSet           fs,
            Tcl_Obj *const       argv[])
 {
   if ((field < 0) || ((unsigned int) field >= fs->num_fields)) {
-    Tcl_AppendResult(fs->item->wi->interp, "invalid field index \"", NULL);
+    Tcl_AppendResult(fs->item->wi->interp, "invalid field index \"", (char *) NULL);
     return TCL_ERROR;
   }
     
@@ -2195,7 +2195,7 @@ PsField(ZnWInfo *wi,
         /* TODO No support yet */
       }
       else { /* Fill stippled */
-        Tcl_AppendResult(wi->interp, "gsave\n", NULL);
+        Tcl_AppendResult(wi->interp, "gsave\n", (char *) NULL);
         if (Tk_PostscriptColor(wi->interp, wi->ps_info,
                                ZnGetGradientColor(fptr->fill_color, 0.0, NULL)) != TCL_OK) {
           return TCL_ERROR;
@@ -2204,7 +2204,7 @@ PsField(ZnWInfo *wi,
                                  ZnImagePixmap(fptr->tile, wi->win)) != TCL_OK) {
           return TCL_ERROR;
         }
-        Tcl_AppendResult(wi->interp, "grestore\n", NULL);
+        Tcl_AppendResult(wi->interp, "grestore\n", (char *) NULL);
       }
     }
     else { /* Fill solid */
@@ -2212,7 +2212,7 @@ PsField(ZnWInfo *wi,
                              ZnGetGradientColor(fptr->fill_color, 0.0, NULL)) != TCL_OK) {
         return TCL_ERROR;
       }
-      Tcl_AppendResult(wi->interp, "fill\n", NULL);
+      Tcl_AppendResult(wi->interp, "fill\n", (char *) NULL);
     }
   }
 
@@ -2229,21 +2229,21 @@ PsField(ZnWInfo *wi,
       if (fptr->image != ZnUnspecifiedImage) {
 	int w, h;
 
-        Tcl_AppendResult(wi->interp, "gsave\n", NULL);
+        Tcl_AppendResult(wi->interp, "gsave\n", (char *) NULL);
         sprintf(path, "%.15g %.15g translate 1 -1 scale\n",
                 pm_bbox->orig.x, pm_bbox->corner.y);
-        Tcl_AppendResult(wi->interp, path, NULL);
+        Tcl_AppendResult(wi->interp, path, (char *) NULL);
         w = ZnNearestInt(pm_bbox->corner.x - pm_bbox->orig.x);
         h = ZnNearestInt(pm_bbox->corner.y - pm_bbox->orig.y);
         if (Tk_PostscriptImage(ZnImageTkImage(fptr->image), wi->interp, wi->win,
                                wi->ps_info, 0, 0, w, h, prepass) != TCL_OK) {
           return TCL_ERROR;
         }
-        Tcl_AppendResult(wi->interp, "grestore\n", NULL);
+        Tcl_AppendResult(wi->interp, "grestore\n", (char *) NULL);
       }
     }
     else if (fptr->text) {
-      Tcl_AppendResult(wi->interp, "gsave\n", NULL);
+      Tcl_AppendResult(wi->interp, "gsave\n", (char *) NULL);
       if (Tk_PostscriptFont(wi->interp, wi->ps_info, fptr->font) != TCL_OK) {
         return TCL_ERROR;
       }
@@ -2258,13 +2258,13 @@ PsField(ZnWInfo *wi,
        */
       sprintf(path, "%.15g %.15g translate 1 -1 scale 0 0 [\n",
               text_bbox->orig.x, text_bbox->orig.y);
-      Tcl_AppendResult(wi->interp, path, NULL);
+      Tcl_AppendResult(wi->interp, path, (char *) NULL);
       /*
        * strlen should do the work of counting _bytes_ in the utf8 string.
        */
       ZnPostscriptString(wi->interp, fptr->text, strlen(fptr->text));
-      Tcl_AppendResult(wi->interp, "] 0 0.0 0.0 0.0 false DrawText\n", NULL);
-      Tcl_AppendResult(wi->interp, "grestore\n", NULL);
+      Tcl_AppendResult(wi->interp, "] 0 0.0 0.0 0.0 false DrawText\n", (char *) NULL);
+      Tcl_AppendResult(wi->interp, "grestore\n", (char *) NULL);
     }
   }
 
@@ -2282,36 +2282,36 @@ PsField(ZnWInfo *wi,
                            ZnGetGradientColor(fptr->border_color, 0.0, NULL)) != TCL_OK) {
       return TCL_ERROR;
     }
-    Tcl_AppendResult(wi->interp, "1 setlinewidth 0 setlinejoin 2 setlinecap\n", NULL);
+    Tcl_AppendResult(wi->interp, "1 setlinewidth 0 setlinejoin 2 setlinecap\n", (char *) NULL);
     if (fptr->border_edges & ZN_LEFT_BORDER) {
       sprintf(path, "%.15g %.15g moveto %.15g %.15g lineto stroke\n",
               bbox->orig.x, bbox->orig.y, bbox->orig.x, bbox->corner.y);
-      Tcl_AppendResult(wi->interp, path, NULL);
+      Tcl_AppendResult(wi->interp, path, (char *) NULL);
     }
     if (fptr->border_edges & ZN_RIGHT_BORDER) {
       sprintf(path, "%.15g %.15g moveto %.15g %.15g lineto stroke\n",
               bbox->corner.x, bbox->orig.y, bbox->corner.x, bbox->corner.y);
-      Tcl_AppendResult(wi->interp, path, NULL);
+      Tcl_AppendResult(wi->interp, path, (char *) NULL);
     }
     if (fptr->border_edges & ZN_TOP_BORDER) {
       sprintf(path, "%.15g %.15g moveto %.15g %.15g lineto stroke\n",
               bbox->orig.x, bbox->orig.y, bbox->corner.x, bbox->orig.y);
-      Tcl_AppendResult(wi->interp, path, NULL);
+      Tcl_AppendResult(wi->interp, path, (char *) NULL);
     }
     if (fptr->border_edges & ZN_BOTTOM_BORDER) {
       sprintf(path, "%.15g %.15g moveto %.15g %.15g lineto stroke\n",
               bbox->orig.x, bbox->corner.y, bbox->corner.x, bbox->corner.y);
-      Tcl_AppendResult(wi->interp, path, NULL);
+      Tcl_AppendResult(wi->interp, path, (char *) NULL);
     }
     if (fptr->border_edges & ZN_OBLIQUE) {
       sprintf(path, "%.15g %.15g moveto %.15g %.15g lineto stroke\n",
               bbox->orig.x, bbox->orig.y, bbox->corner.x, bbox->corner.y);
-      Tcl_AppendResult(wi->interp, path, NULL);
+      Tcl_AppendResult(wi->interp, path, (char *) NULL);
     }
     if (fptr->border_edges & ZN_COUNTER_OBLIQUE) {
       sprintf(path, "%.15g %.15g moveto %.15g %.15g lineto stroke\n",
               bbox->corner.x, bbox->orig.y, bbox->orig.x, bbox->corner.y);
-      Tcl_AppendResult(wi->interp, path, NULL);
+      Tcl_AppendResult(wi->interp, path, (char *) NULL);
     }
   }
 
@@ -2342,7 +2342,7 @@ PostScriptFields(ZnFieldSet field_set,
      * Fields are drawn with respect to a point already converted
      * to device space, so we need to reinstate the initial transform.
      */
-    Tcl_AppendResult(wi->interp, "/InitialTransform load setmatrix\n", NULL);
+    Tcl_AppendResult(wi->interp, "/InitialTransform load setmatrix\n", (char *) NULL);
 
     lclip_bbox.orig.x = ZnNearestInt(field_set->label_pos.x);
     lclip_bbox.orig.y = ZnNearestInt(field_set->label_pos.y);
@@ -2368,12 +2368,12 @@ PostScriptFields(ZnFieldSet field_set,
       /*
        * Setup a clip area around the field
        */
-      Tcl_AppendResult(wi->interp, "gsave\n", NULL);
+      Tcl_AppendResult(wi->interp, "gsave\n", (char *) NULL);
       sprintf(path, "%.15g %.15g moveto %.15g %.15g lineto %.15g %.15g lineto %.15g %.15g",
               fclip_bbox.orig.x, fclip_bbox.orig.y, fclip_bbox.corner.x+1, fclip_bbox.orig.y,
               fclip_bbox.corner.x+1, fclip_bbox.corner.y+1, fclip_bbox.orig.x,
               fclip_bbox.corner.y+1);
-      Tcl_AppendResult(wi->interp, path, " lineto closepath clip\n", NULL);
+      Tcl_AppendResult(wi->interp, path, " lineto closepath clip\n", (char *) NULL);
 
       if (fptr->text) {
         ComputeFieldTextLocation(fptr, &bbox, &text_pos, &text_bbox);
@@ -2386,7 +2386,7 @@ PostScriptFields(ZnFieldSet field_set,
         return TCL_ERROR;
       }
 
-      Tcl_AppendResult(wi->interp, "grestore\n", NULL);
+      Tcl_AppendResult(wi->interp, "grestore\n", (char *) NULL);
     }
   }
 

--- a/generic/Group.c
+++ b/generic/Group.c
@@ -438,7 +438,7 @@ Configure(ZnItem        item,
         (!group->clip->class->GetClipVertices || (group->clip->parent != item))) {
       group->clip = ZN_NO_ITEM;
       Tcl_AppendResult(wi->interp,
-                       " clip item must be a child of the group", NULL);
+                       " clip item must be a child of the group", (char *) NULL);
       return TCL_ERROR;
     }
     if (!group->clip && (item == wi->top_group)) {
@@ -1413,13 +1413,13 @@ Coords(ZnItem           item,
 {
   if ((cmd == ZN_COORDS_ADD) || (cmd == ZN_COORDS_ADD_LAST) || (cmd == ZN_COORDS_REMOVE)) {
     Tcl_AppendResult(item->wi->interp,
-                     " can't add or remove vertices in groups", NULL);
+                     " can't add or remove vertices in groups", (char *) NULL);
     return TCL_ERROR;
   }
   else if ((cmd == ZN_COORDS_REPLACE) || (cmd == ZN_COORDS_REPLACE_ALL)) {
     if (*num_pts == 0) {
       Tcl_AppendResult(item->wi->interp,
-                       " coords command need 1 point on groups", NULL);
+                       " coords command need 1 point on groups", (char *) NULL);
       return TCL_ERROR;
     }
     if (!item->transfo && ((*pts)[0].x == 0.0) && ((*pts)[0].y == 0.0)) {
@@ -1484,7 +1484,7 @@ PostScript(ZnItem item,
     if (current_item->class != ZnGroup) {
       PushTransform(current_item);
       if (!prepass) {
-        Tcl_AppendResult(wi->interp, "gsave\n", NULL);
+        Tcl_AppendResult(wi->interp, "gsave\n", (char *) NULL);
       }
       ZnPostscriptTrace(current_item, 1);
     }
@@ -1492,7 +1492,7 @@ PostScript(ZnItem item,
     if (current_item->class != ZnGroup) {
       ZnPostscriptTrace(current_item, 0);
       if (!prepass && (result == TCL_OK)) {
-        Tcl_AppendResult(wi->interp, "grestore\n", NULL);
+        Tcl_AppendResult(wi->interp, "grestore\n", (char *) NULL);
       }
       PopTransform(current_item);
     }

--- a/generic/Icon.c
+++ b/generic/Icon.c
@@ -790,7 +790,7 @@ PostScript(ZnItem item,
           wi->current_transfo->_[1][0], wi->current_transfo->_[1][1], 
           wi->current_transfo->_[2][0], wi->current_transfo->_[2][1],
           origin.x, origin.y - h);
-  Tcl_AppendResult(wi->interp, path, NULL);
+  Tcl_AppendResult(wi->interp, path, (char *) NULL);
   
   if (ZnImageIsBitmap(icon->image)) {
     if (Tk_PostscriptColor(wi->interp, wi->ps_info,
@@ -888,13 +888,13 @@ Coords(ZnItem           item,
   
   if ((cmd == ZN_COORDS_ADD) || (cmd == ZN_COORDS_ADD_LAST) || (cmd == ZN_COORDS_REMOVE)) {
     Tcl_AppendResult(item->wi->interp,
-                     " icons can't add or remove vertices", NULL);
+                     " icons can't add or remove vertices", (char *) NULL);
     return TCL_ERROR;
   }
   else if ((cmd == ZN_COORDS_REPLACE) || (cmd == ZN_COORDS_REPLACE_ALL)) {
     if (*num_pts == 0) {
       Tcl_AppendResult(item->wi->interp,
-                       " coords command need 1 point on icons", NULL);
+                       " coords command need 1 point on icons", (char *) NULL);
       return TCL_ERROR;
     }
     icon->pos = (*pts)[0];

--- a/generic/Item.c
+++ b/generic/Item.c
@@ -217,7 +217,7 @@ GetAttrDesc(Tcl_Interp          *interp,
 
   while (True) {
     if (desc->type == ZN_CONFIG_END) {
-      Tcl_AppendResult(interp, "unknown attribute \"", attr_uid, "\"", NULL);
+      Tcl_AppendResult(interp, "unknown attribute \"", attr_uid, "\"", (char *) NULL);
       return NULL;
     }
     else if (attr_uid == desc->uid) {
@@ -313,7 +313,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
     }
     else if (desc->read_only) {
       Tcl_AppendResult(wi->interp, "attribute \"",
-                       Tcl_GetString(args[i]), "\" can only be read", NULL);
+                       Tcl_GetString(args[i]), "\" can only be read", (char *) NULL);
       return TCL_ERROR;
     }
 
@@ -333,7 +333,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
           if (!g) {
             Tcl_AppendResult(wi->interp,
                              " gradient expected for attribute \"",
-                             Tcl_GetString(args[i]), "\"", NULL);
+                             Tcl_GetString(args[i]), "\"", (char *) NULL);
             return TCL_ERROR;
           }
           if (*((ZnGradient **) valp)) {
@@ -356,7 +356,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
                                    &num_grads, &elems) == TCL_ERROR) {
           Tcl_AppendResult(wi->interp,
                            " gradient list expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (num_grads) {
@@ -377,7 +377,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
             if (!grads[j]) {
             grads_err:
               Tcl_AppendResult(wi->interp, " invalid gradient \"", str,
-                               "\" in gradient list", NULL);
+                               "\" in gradient list", (char *) NULL);
               for (k = 0; k < j; k++) {
                 ZnFreeGradient(grads[k]);
               }
@@ -411,7 +411,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
         int     b;
         if (Tcl_GetBooleanFromObj(wi->interp, args[i+1], &b) != TCL_OK) {
           Tcl_AppendResult(wi->interp, " boolean expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (b ^ (ISSET(*((unsigned short *) valp), desc->bool_bit) != 0)) {
@@ -437,7 +437,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
               image = ZnGetImage(wi, str, ZnUpdateItemImage, record);
               if (image == ZnUnspecifiedImage) {
                 Tcl_AppendResult(wi->interp, " image expected for attribute \"",
-                                 Tcl_GetString(args[i]), "\"", NULL);
+                                 Tcl_GetString(args[i]), "\"", (char *) NULL);
                 return TCL_ERROR;
               }
             }
@@ -449,7 +449,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
                   ZnFreeImage(image, NULL, NULL);
                 }
                 Tcl_AppendResult(wi->interp, " bitmap expected for attribute \"",
-                                 Tcl_GetString(args[i]), "\"", NULL);
+                                 Tcl_GetString(args[i]), "\"", (char *) NULL);
                 return TCL_ERROR;
               }
             }
@@ -475,7 +475,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
                                    &num_pats, &elems) == TCL_ERROR) {
           Tcl_AppendResult(wi->interp,
                            " pattern list expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (num_pats) {
@@ -496,7 +496,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
                 }
                 ZnListFree(new_pat_list);
                 Tcl_AppendResult(wi->interp, " unknown pattern \"", str,
-                                 "\" in pattern list", NULL);
+                                 "\" in pattern list", (char *) NULL);
                 return TCL_ERROR;
               }
             }
@@ -534,7 +534,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
                                    &num_tags, &elems) == TCL_ERROR) {
           Tcl_AppendResult(wi->interp,
                            " tag list expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (*((ZnList *) valp)) {
@@ -579,7 +579,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
           font = Tk_GetFont(wi->interp, wi->win, str);
           if (!font) {
             Tcl_AppendResult(wi->interp, " font expected for attribute \"",
-                             Tcl_GetString(args[i]), "\"", NULL);
+                             Tcl_GetString(args[i]), "\"", (char *) NULL);
             return TCL_ERROR;
           }
           if (*((Tk_Font *) valp)) {
@@ -596,7 +596,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
 
         if (ZnGetBorder(wi, args[i+1], &border) == TCL_ERROR) {
           Tcl_AppendResult(wi->interp, " edge list expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (border != *((ZnBorder *) valp)) {
@@ -611,7 +611,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
 
         if (ZnGetLineShape(wi, Tcl_GetString(args[i+1]), &line_shape) == TCL_ERROR) {
           Tcl_AppendResult(wi->interp, " line shape expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (line_shape != *((ZnLineShape *) valp)) {
@@ -626,7 +626,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
 
         if (ZnGetLineStyle(wi, Tcl_GetString(args[i+1]), &line_style) == TCL_ERROR) {
           Tcl_AppendResult(wi->interp, " line style expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (line_style != *((ZnLineStyle *) valp)) {
@@ -663,7 +663,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
         ZnReliefStyle relief;
         if (ZnGetRelief(wi, Tcl_GetString(args[i+1]), &relief) == TCL_ERROR) {
           Tcl_AppendResult(wi->interp, " relief expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (relief != *((ZnReliefStyle *) valp)) {
@@ -678,7 +678,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
         int     join;
         if (Tk_GetJoinStyle(wi->interp, Tcl_GetString(args[i+1]), &join) == TCL_ERROR) {
           Tcl_AppendResult(wi->interp, " join expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (join != *((int *) valp)) {
@@ -692,7 +692,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
         int     cap;
         if (Tk_GetCapStyle(wi->interp, Tcl_GetString(args[i+1]), &cap) == TCL_ERROR) {
           Tcl_AppendResult(wi->interp, " cap expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (cap != *((int *) valp)) {
@@ -713,7 +713,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
             (largc != 2)) {
         point_error:
           Tcl_AppendResult(wi->interp, " position expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (Tcl_GetDoubleFromObj(wi->interp, largv[0], &d) == TCL_ERROR) {
@@ -766,7 +766,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
         }
         if (pri < 0) {
           Tcl_AppendResult(wi->interp, " priority must be a positive integer \"",
-                           Tcl_GetString(args[i+1]), "\"", NULL);
+                           Tcl_GetString(args[i+1]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (pri != *((unsigned short *) valp)) {
@@ -795,7 +795,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
           ZnTagSearchDestroy(search_var);
           if ((result == TCL_ERROR) || (item2 == ZN_NO_ITEM)) {
             Tcl_AppendResult(wi->interp, " unknown item \"",
-                             Tcl_GetString(args[i+1]), "\"", NULL);
+                             Tcl_GetString(args[i+1]), "\"", (char *) NULL);
             return TCL_ERROR;
           }
         }
@@ -936,7 +936,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
 
         if (ZnGetFillRule(wi, Tcl_GetString(args[i+1]), &fill_rule) == TCL_ERROR) {
           Tcl_AppendResult(wi->interp, " fill rule expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (fill_rule != *((ZnFillRule *) valp)) {
@@ -950,7 +950,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
         Tk_Justify justify;
         if (Tk_GetJustify(wi->interp, Tcl_GetString(args[i+1]), &justify) == TCL_ERROR) {
           Tcl_AppendResult(wi->interp, " justify expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (justify != *((Tk_Justify *) valp)) {
@@ -964,7 +964,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
         Tk_Anchor       anchor;
         if (Tk_GetAnchor(wi->interp, Tcl_GetString(args[i+1]), &anchor) == TCL_ERROR) {
           Tcl_AppendResult(wi->interp, " anchor expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (anchor != *((Tk_Anchor *) valp)) {
@@ -1009,7 +1009,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
 
         if (ZnGetAutoAlign(wi, Tcl_GetString(args[i+1]), &aa) == TCL_ERROR) {
           Tcl_AppendResult(wi->interp, " auto alignment expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if ((aa.automatic != ((ZnAutoAlign *) valp)->automatic) ||
@@ -1027,7 +1027,7 @@ ZnConfigureAttributes(ZnWInfo           *wi,
         ZnLeaderAnchors lanch = NULL;
         if (ZnGetLeaderAnchors(wi, Tcl_GetString(args[i+1]), &lanch) == TCL_ERROR) {
           Tcl_AppendResult(wi->interp, " leader anchors expected for attribute \"",
-                           Tcl_GetString(args[i]), "\"", NULL);
+                           Tcl_GetString(args[i]), "\"", (char *) NULL);
           return TCL_ERROR;
         }
         if (*((ZnLeaderAnchors *) valp) != NULL) {

--- a/generic/MapInfo.c
+++ b/generic/MapInfo.c
@@ -1359,7 +1359,7 @@ ZnDuplicateZnMapInfo(Tcl_Interp *interp,
   
   entry = Tcl_CreateHashEntry(&mapInfoTable, uid, &new);
   if (!new) {
-    Tcl_AppendResult(interp, "duplicate mapinfo \"", name, "\" already exists", NULL);
+    Tcl_AppendResult(interp, "duplicate mapinfo \"", name, "\" already exists", (char *) NULL);
     return TCL_ERROR;
   }
   master = (ZnMapInfoMaster *) ZnMalloc(sizeof(ZnMapInfoMaster));
@@ -1386,7 +1386,7 @@ LookupMapInfoMaster(Tcl_Interp  *interp,
   entry = Tcl_FindHashEntry(&mapInfoTable, uid);
   if (entry == NULL) {
   mp_error:
-    Tcl_AppendResult(interp, "mapinfo \"", name, "\" doesn't exist", NULL);
+    Tcl_AppendResult(interp, "mapinfo \"", name, "\" doesn't exist", (char *) NULL);
     return NULL;
   }
   master = (ZnMapInfoMaster *) Tcl_GetHashValue(entry);
@@ -1537,7 +1537,7 @@ ZnMapInfoLineStyleFromString(Tcl_Interp         *interp,
     }
   }
   Tcl_AppendResult(interp, " incorrect mapinfo line style \"",
-                   str,"\"", NULL);
+                   str,"\"", (char *) NULL);
   return TCL_ERROR;
 }
 
@@ -1561,7 +1561,7 @@ ZnMapInfoTextStyleFromString(Tcl_Interp         *interp,
     }
   }
   Tcl_AppendResult(interp, " incorrect mapinfo text style \"",
-                   str,"\"", NULL);
+                   str,"\"", (char *) NULL);
   return TCL_ERROR;
 }
 
@@ -2090,7 +2090,7 @@ ZnVideomapObjCmd(ClientData     client_data,
       ids = ZnMapInfoVideomapIds(Tcl_GetString(args[2]));
       if (ids == NULL) {
         Tcl_AppendResult(interp, "unable to look at videomap file \"",
-                         Tcl_GetString(args[2]), "\"", NULL);
+                         Tcl_GetString(args[2]), "\"", (char *) NULL);
         return TCL_ERROR;
       }
       id_array = ZnListArray(ids);
@@ -2126,7 +2126,7 @@ ZnVideomapObjCmd(ClientData     client_data,
       if (ZnMapInfoGetVideomap(map_info, Tcl_GetString(args[2]), insert) == TCL_ERROR) {
         Tcl_AppendResult(interp, "unable to load videomap file \"",
                          Tcl_GetString(args[2]), ":",
-                         Tcl_GetString(args[3]), "\"", NULL);
+                         Tcl_GetString(args[3]), "\"", (char *) NULL);
         return TCL_ERROR;
       }
       ZnUpdateMapInfoClients(map_info);

--- a/generic/PostScript.c
+++ b/generic/PostScript.c
@@ -573,7 +573,7 @@ ZnPostScriptCmd(ZnWInfo        *wi,
     /*
      * Save the base matrix for further reference.
      */
-    Tcl_AppendResult(wi->interp, "/InitialTransform matrix currentmatrix def\n", NULL);
+    Tcl_AppendResult(wi->interp, "/InitialTransform matrix currentmatrix def\n", (char *) NULL);
 
     sprintf(string, "%d %.15g moveto %d %.15g lineto %d %.15g lineto %d %.15g",
             ps_info.x, Tk_PostscriptY((double) ps_info.y, (Tk_PostscriptInfo) &ps_info),
@@ -679,7 +679,7 @@ ZnPostscriptOutline(Tcl_Interp        *interp,
   int patlen = 0;
 
   sprintf(string, "%.15g setlinewidth\n", (double) line_width);
-  Tcl_AppendResult(interp, string, NULL);
+  Tcl_AppendResult(interp, string, (char *) NULL);
   /*
    * Setup the line style. It is dependent on the line
    * width.
@@ -703,23 +703,23 @@ ZnPostscriptOutline(Tcl_Interp        *interp,
     while (--patlen) {
       sprintf(string+strlen(string), " %d", ((*pattern++) * (int) line_width) & 0xff);
     }
-    Tcl_AppendResult(interp, string, NULL);
+    Tcl_AppendResult(interp, string, (char *) NULL);
     sprintf(string, "] %d setdash\n", 0 /* dash offset */);
-    Tcl_AppendResult(interp, string, NULL);
+    Tcl_AppendResult(interp, string, (char *) NULL);
   }
   if (Tk_PostscriptColor(interp, ps_info,
                          ZnGetGradientColor(line_color, 0.0, NULL)) != TCL_OK) {
     return TCL_ERROR;
   }
   if (line_pattern != ZnUnspecifiedImage) {
-    Tcl_AppendResult(interp, "StrokeClip ", NULL);
+    Tcl_AppendResult(interp, "StrokeClip ", (char *) NULL);
     if (Tk_PostscriptStipple(interp, tkwin, ps_info,
                              ZnImagePixmap(line_pattern, tkwin)) != TCL_OK) {
       return TCL_ERROR;
     }
   }
   else {
-    Tcl_AppendResult(interp, "stroke\n", NULL);
+    Tcl_AppendResult(interp, "stroke\n", (char *) NULL);
   }
   
   return TCL_OK;
@@ -762,7 +762,7 @@ ZnPostscriptBitmap(Tcl_Interp        *interp,
   if (width > 60000) {
     Tcl_ResetResult(interp);
     Tcl_AppendResult(interp, "can't generate Postscript",
-                     " for bitmaps more than 60000 pixels wide", NULL);
+                     " for bitmaps more than 60000 pixels wide", (char *) NULL);
     return TCL_ERROR;
   }
   rows_at_once = 60000/width;
@@ -770,7 +770,7 @@ ZnPostscriptBitmap(Tcl_Interp        *interp,
     rows_at_once = 1;
   }
   sprintf(buffer, "%.15g %.15g translate\n", x, y + height);
-  Tcl_AppendResult(interp, buffer, NULL);
+  Tcl_AppendResult(interp, buffer, (char *) NULL);
   for (cur_row = 0; cur_row < height; cur_row += rows_at_once) {
     rows_this_time = rows_at_once;
     if (rows_this_time > (height - cur_row)) {
@@ -778,7 +778,7 @@ ZnPostscriptBitmap(Tcl_Interp        *interp,
     }
     sprintf(buffer, "0 -%.15g translate\n%d %d true matrix {\n",
             (double) rows_this_time, width, rows_this_time);
-    Tcl_AppendResult(interp, buffer, NULL);
+    Tcl_AppendResult(interp, buffer, (char *) NULL);
     if (Tk_PostscriptBitmap(interp, tkwin, ps_info,  ZnImagePixmap(bitmap, tkwin),
                             0, cur_row, width, rows_this_time) != TCL_OK) {
       return TCL_ERROR;
@@ -852,7 +852,7 @@ ZnPostscriptString(Tcl_Interp   *interp,
         }
         if ((used + strlen(glyphname)) >= MAXUSE) {
           buf[used] = '\0';
-          Tcl_AppendResult(interp, buf, NULL);
+          Tcl_AppendResult(interp, buf, (char *) NULL);
           used = 0;
         }
         buf[used++] = '/';
@@ -864,7 +864,7 @@ ZnPostscriptString(Tcl_Interp   *interp,
     }
     if (used >= MAXUSE) {
       buf[used] = '\0';
-      Tcl_AppendResult(interp, buf, NULL);
+      Tcl_AppendResult(interp, buf, (char *) NULL);
       used = 0;
     }
   }
@@ -872,7 +872,7 @@ ZnPostscriptString(Tcl_Interp   *interp,
   buf[used++] = ']';
   buf[used++] = '\n';
   buf[used] = '\0';
-  Tcl_AppendResult(interp, buf, NULL);
+  Tcl_AppendResult(interp, buf, (char *) NULL);
 
 #endif
 }
@@ -887,10 +887,10 @@ ZnPostscriptTile(Tcl_Interp        *interp,
   int  w, h;
 
   ZnSizeOfImage(image, &w, &h);
-  Tcl_AppendResult(interp, "<< /PatternType 1 /PaintType 1 /TilingType 1\n", NULL);
+  Tcl_AppendResult(interp, "<< /PatternType 1 /PaintType 1 /TilingType 1\n", (char *) NULL);
   sprintf(path, "  /BBox [%.15g %.15g %.15g %.15g] /XStep %.15g /YStep %.15g\n",
           0.0, (double) h, (double) w, 0.0, (double) w, (double) h);
-  Tcl_AppendResult(interp, path, "  /PaintProc { begin\n", NULL);
+  Tcl_AppendResult(interp, path, "  /PaintProc { begin\n", (char *) NULL);
 
   /*
    * On ne peut pas reprendre le code de Tk_PostscriptImage,
@@ -902,7 +902,7 @@ ZnPostscriptTile(Tcl_Interp        *interp,
     return TCL_ERROR;
   }
 
-  Tcl_AppendResult(interp, "end } bind >> matrix makepattern setpattern fill\n", NULL);
+  Tcl_AppendResult(interp, "end } bind >> matrix makepattern setpattern fill\n", (char *) NULL);
 
   return TCL_OK;
 }
@@ -917,7 +917,7 @@ ZnPostscriptTrace(ZnItem item,
   if (wi->debug) {
     sprintf(buf, "%%%%%%%% %s for %s %d %%%%%%%%\n",
             enter ? "Code" : "End of code", item->class->name, item->id);
-    Tcl_AppendResult(wi->interp, buf, NULL);
+    Tcl_AppendResult(wi->interp, buf, (char *) NULL);
   }
 }
 
@@ -937,7 +937,7 @@ ZnPostscriptGradient(Tcl_Interp        *interp,
     return TCL_OK;
   }
 
-  Tcl_AppendResult(interp, "<< /PatternType 2 /Shading\n", NULL);
+  Tcl_AppendResult(interp, "<< /PatternType 2 /Shading\n", (char *) NULL);
 
   switch (gradient->type) {
     case ZN_AXIAL_GRADIENT:
@@ -964,10 +964,10 @@ ZnPostscriptGradient(Tcl_Interp        *interp,
       }
       Tcl_AppendResult(interp,
                        "  << /ShadingType 2 /ColorSpace /DeviceRGB /Extend [true true] ",
-                       NULL); 
+                       (char *) NULL);
       sprintf(path, "/Coords [%.15g %.15g %.15g %.15g]\n",
               quad[0].x, quad[0].y, quad[1].x, quad[1].y);
-      Tcl_AppendResult(interp, path, NULL);
+      Tcl_AppendResult(interp, path, (char *) NULL);
       break;
     case ZN_RADIAL_GRADIENT:
       /*
@@ -984,11 +984,11 @@ ZnPostscriptGradient(Tcl_Interp        *interp,
       ZnTransformPoint((ZnTransfo *) quad, &p, &extent);
       Tcl_AppendResult(interp,
                        "  << /ShadingType 3 /ColorSpace /DeviceRGB /Extend [true true] ",
-                       NULL); 
+                       (char *) NULL);
       sprintf(path, "/Coords [%.15g %.15g %.15g %.15g %.15g %.15g]\n",
               center.x, center.y, 0.0, center.x, center.y, ABS(center.x-extent.x));
       printf("center %g %g, radius %g\n", center.x, center.y, ABS(center.x-extent.x));
-      Tcl_AppendResult(interp, path, NULL);
+      Tcl_AppendResult(interp, path, (char *) NULL);
       break;
     case ZN_CONICAL_GRADIENT:
       break;
@@ -996,30 +996,30 @@ ZnPostscriptGradient(Tcl_Interp        *interp,
       break;
   }
 
-  Tcl_AppendResult(interp, "    /Function << ", NULL);
-  Tcl_AppendResult(interp, "/FunctionType 3\n", NULL);
-  Tcl_AppendResult(interp, "      /Domain [0 1] /Bounds [", NULL);
+  Tcl_AppendResult(interp, "    /Function << ", (char *) NULL);
+  Tcl_AppendResult(interp, "/FunctionType 3\n", (char *) NULL);
+  Tcl_AppendResult(interp, "      /Domain [0 1] /Bounds [", (char *) NULL);
   for (i = 1; i < gradient->num_actual_colors-1; i++) {
     sprintf(path, "%.4g ", gradient->actual_colors[i].position/100.0);
-    Tcl_AppendResult(interp, path, NULL);
+    Tcl_AppendResult(interp, path, (char *) NULL);
   }
-  Tcl_AppendResult(interp, "] /Encode [", NULL);
+  Tcl_AppendResult(interp, "] /Encode [", (char *) NULL);
   for (i = 0; i < gradient->num_actual_colors-1; i++) {
-    Tcl_AppendResult(interp, "0 1 ", NULL);
+    Tcl_AppendResult(interp, "0 1 ", (char *) NULL);
   }
-  Tcl_AppendResult(interp, "]\n      /Functions [\n", NULL);
+  Tcl_AppendResult(interp, "]\n      /Functions [\n", (char *) NULL);
   for (i = 0, gc1 = gradient->actual_colors; i < gradient->num_actual_colors-1; i++) {
     gc2 = gc1 + 1;
-    Tcl_AppendResult(interp, "      << /FunctionType 2 /Domain [0 1] /N 1 ", NULL);
+    Tcl_AppendResult(interp, "      << /FunctionType 2 /Domain [0 1] /N 1 ", (char *) NULL);
     sprintf(path, "/C0 [%.8g %.8g %.8g] /C1 [%.8g %.8g %.8g] >>\n",
             gc1->rgb->red/65535.0, gc1->rgb->green/65535.0, gc1->rgb->blue/65535.0,
             gc2->rgb->red/65535.0, gc2->rgb->green/65535.0, gc2->rgb->blue/65535.0);
-    Tcl_AppendResult(interp, path, NULL);
+    Tcl_AppendResult(interp, path, (char *) NULL);
     gc1 = gc2;
   }
-  Tcl_AppendResult(interp, "      ] >>\n", NULL);
-  Tcl_AppendResult(interp, "  >> >>\n", NULL);
-  Tcl_AppendResult(interp, "matrix makepattern setpattern fill\n", NULL);
+  Tcl_AppendResult(interp, "      ] >>\n", (char *) NULL);
+  Tcl_AppendResult(interp, "  >> >>\n", (char *) NULL);
+  Tcl_AppendResult(interp, "matrix makepattern setpattern fill\n", (char *) NULL);
 
   return TCL_OK;
 }
@@ -1168,7 +1168,7 @@ ZnPostscriptXImage(Tcl_Interp        *interp,
     return TCL_OK;
   }
 
-  Tcl_AppendResult(interp, "%%%%%% Start of ZnPostscriptXImage\n", NULL);
+  Tcl_AppendResult(interp, "%%%%%% Start of ZnPostscriptXImage\n", (char *) NULL);
 
   cmap = Tk_Colormap(tkwin);
   visual = Tk_Visual(tkwin);
@@ -1363,7 +1363,7 @@ ZnPostscriptXImage(Tcl_Interp        *interp,
   }
   ckfree((char *) cdata.colors);
 
-  Tcl_AppendResult(interp, "%%%%%% End of ZnPostscriptXImage\n", NULL);
+  Tcl_AppendResult(interp, "%%%%%% End of ZnPostscriptXImage\n", (char *) NULL);
 
   return TCL_OK;
 }

--- a/generic/Rectangle.c
+++ b/generic/Rectangle.c
@@ -143,7 +143,7 @@ Init(ZnItem             item,
   item->priority = 1;
   
   if (*argc < 1) {
-    Tcl_AppendResult(wi->interp, " rectangle coords expected", NULL);
+    Tcl_AppendResult(wi->interp, " rectangle coords expected", (char *) NULL);
     return TCL_ERROR;
   }
   if (ZnParseCoordList(wi, (*args)[0], &points,
@@ -151,7 +151,7 @@ Init(ZnItem             item,
     return TCL_ERROR;
   }
   if (num_points != 2) {
-    Tcl_AppendResult(wi->interp, " malformed rectangle coords", NULL);
+    Tcl_AppendResult(wi->interp, " malformed rectangle coords", (char *) NULL);
     return TCL_ERROR;
   };
   rect->coords[0] = points[0];
@@ -774,14 +774,14 @@ PostScript(ZnItem item,
   sprintf(path, "%.15g %.15g moveto %.15g %.15g lineto %.15g %.15g lineto %.15g %.15g lineto closepath\n",
           rect->dev[0].x, rect->dev[0].y, rect->dev[1].x, rect->dev[1].y,
           rect->dev[2].x, rect->dev[2].y, rect->dev[3].x, rect->dev[3].y);
-  Tcl_AppendResult(wi->interp, path, NULL);
+  Tcl_AppendResult(wi->interp, path, (char *) NULL);
 
   /*
    * Emit code to draw the filled area.
    */
   if (ISSET(rect->flags, FILLED_BIT)) {
     if (rect->line_width) {
-      Tcl_AppendResult(wi->interp, "gsave\n", NULL);
+      Tcl_AppendResult(wi->interp, "gsave\n", (char *) NULL);
     }
     if (!ZnGradientFlat(rect->fill_color)) {
       if (ZnPostscriptGradient(wi->interp, wi->ps_info, rect->fill_color,
@@ -800,7 +800,7 @@ PostScript(ZnItem item,
                                ZnGetGradientColor(rect->fill_color, 0.0, NULL)) != TCL_OK) {
           return TCL_ERROR;
         }
-        Tcl_AppendResult(wi->interp, "clip ", NULL);
+        Tcl_AppendResult(wi->interp, "clip ", (char *) NULL);
         if (ZnPostscriptStipple(wi->interp, wi->win, wi->ps_info, rect->tile) != TCL_OK) {
           return TCL_ERROR;
         }
@@ -811,10 +811,10 @@ PostScript(ZnItem item,
                              ZnGetGradientColor(rect->fill_color, 0.0, NULL)) != TCL_OK) {
         return TCL_ERROR;
       }
-      Tcl_AppendResult(wi->interp, "fill\n", NULL);
+      Tcl_AppendResult(wi->interp, "fill\n", (char *) NULL);
     }
     if (rect->line_width) {
-      Tcl_AppendResult(wi->interp, "grestore\n", NULL);
+      Tcl_AppendResult(wi->interp, "grestore\n", (char *) NULL);
     }
   }
 
@@ -826,7 +826,7 @@ PostScript(ZnItem item,
       /* TODO No support yet */
     }
     else {
-      Tcl_AppendResult(wi->interp, "0 setlinejoin 2 setlinecap\n", NULL);
+      Tcl_AppendResult(wi->interp, "0 setlinejoin 2 setlinecap\n", (char *) NULL);
       if (ZnPostscriptOutline(wi->interp, wi->ps_info, wi->win,
                               rect->line_width, rect->line_style,
                               rect->line_color, rect->line_pattern) != TCL_OK) {
@@ -913,13 +913,13 @@ Coords(ZnItem           item,
 
   if ((cmd == ZN_COORDS_ADD) || (cmd == ZN_COORDS_ADD_LAST) || (cmd == ZN_COORDS_REMOVE)) {
     Tcl_AppendResult(item->wi->interp,
-                     " rectangles can't add or remove vertices", NULL);
+                     " rectangles can't add or remove vertices", (char *) NULL);
     return TCL_ERROR;
   }
   else if (cmd == ZN_COORDS_REPLACE_ALL) {
     if (*num_pts != 2) {
       Tcl_AppendResult(item->wi->interp,
-                       " coords command need 2 points on rectangles", NULL);
+                       " coords command need 2 points on rectangles", (char *) NULL);
       return TCL_ERROR;
     }
     rect->coords[0] = (*pts)[0];
@@ -929,7 +929,7 @@ Coords(ZnItem           item,
   else if (cmd == ZN_COORDS_REPLACE) {
     if (*num_pts < 1) {
       Tcl_AppendResult(item->wi->interp,
-                       " coords command need at least 1 point", NULL);
+                       " coords command need at least 1 point", (char *) NULL);
       return TCL_ERROR;
     }
     if (index < 0) {
@@ -938,7 +938,7 @@ Coords(ZnItem           item,
     if ((index < 0) || (index > 1)) {
     range_err:
       Tcl_AppendResult(item->wi->interp,
-                       " incorrect coord index, should be between -2 and 1", NULL);
+                       " incorrect coord index, should be between -2 and 1", (char *) NULL);
       return TCL_ERROR;
     }
     rect->coords[index] = (*pts)[0];

--- a/generic/Reticle.c
+++ b/generic/Reticle.c
@@ -543,13 +543,13 @@ Coords(ZnItem           item,
   
   if ((cmd == ZN_COORDS_ADD) || (cmd == ZN_COORDS_ADD_LAST) || (cmd == ZN_COORDS_REMOVE)) {
     Tcl_AppendResult(item->wi->interp,
-                     " reticles can't add or remove vertices", NULL);
+                     " reticles can't add or remove vertices", (char *) NULL);
     return TCL_ERROR;
   }
   else if ((cmd == ZN_COORDS_REPLACE) || (cmd == ZN_COORDS_REPLACE_ALL)) {
     if (*num_pts == 0) {
       Tcl_AppendResult(item->wi->interp,
-                       " coords command need 1 point on reticles", NULL);
+                       " coords command need 1 point on reticles", (char *) NULL);
       return TCL_ERROR;
     }
     reticle->pos = (*pts)[0];

--- a/generic/Tabular.c
+++ b/generic/Tabular.c
@@ -135,7 +135,7 @@ Init(ZnItem             item,
     ZnFIELD.InitFields(field_set);
   }
   else {
-    Tcl_AppendResult(wi->interp, " number of fields expected", NULL);
+    Tcl_AppendResult(wi->interp, " number of fields expected", (char *) NULL);
     return TCL_ERROR;
   }    
   
@@ -504,13 +504,13 @@ Coords(ZnItem           item,
   
   if ((cmd == ZN_COORDS_ADD) || (cmd == ZN_COORDS_ADD_LAST) || (cmd == ZN_COORDS_REMOVE)) {
     Tcl_AppendResult(item->wi->interp,
-                     " tabulars can't add or remove vertices", NULL);
+                     " tabulars can't add or remove vertices", (char *) NULL);
     return TCL_ERROR;
   }
   else if ((cmd == ZN_COORDS_REPLACE) || (cmd == ZN_COORDS_REPLACE_ALL)) {
     if (*num_pts == 0) {
       Tcl_AppendResult(item->wi->interp,
-                       " coords command need 1 point on tabulars", NULL);
+                       " coords command need 1 point on tabulars", (char *) NULL);
       return TCL_ERROR;
     }
     tabular->pos = (*pts)[0];
@@ -554,7 +554,7 @@ Part(ZnItem     item,
     }
     else {
     part_error:
-      Tcl_AppendResult(item->wi->interp, " invalid item part specification", NULL);
+      Tcl_AppendResult(item->wi->interp, " invalid item part specification", (char *) NULL);
       return TCL_ERROR; 
     }
   }

--- a/generic/Text.c
+++ b/generic/Text.c
@@ -1379,10 +1379,10 @@ PostScript(ZnItem item,
     return TCL_ERROR;
   }
   if (text->fill_pattern != ZnUnspecifiedImage) {
-    Tcl_AppendResult(wi->interp, "/StippleText {\n    ", NULL);
+    Tcl_AppendResult(wi->interp, "/StippleText {\n    ", (char *) NULL);
     Tk_PostscriptStipple(wi->interp, wi->win, wi->ps_info,
                          ZnImagePixmap(text->fill_pattern, wi->win));
-    Tcl_AppendResult(wi->interp, "} bind def\n", NULL);
+    Tcl_AppendResult(wi->interp, "} bind def\n", (char *) NULL);
   }
 
   ComputeTransfoAndOrigin(item, &origin);
@@ -1393,10 +1393,10 @@ PostScript(ZnItem item,
           wi->current_transfo->_[0][0], wi->current_transfo->_[0][1], 
           wi->current_transfo->_[1][0], wi->current_transfo->_[1][1], 
           wi->current_transfo->_[2][0], wi->current_transfo->_[2][1]);
-  Tcl_AppendResult(wi->interp, path, NULL);
+  Tcl_AppendResult(wi->interp, path, (char *) NULL);
 
   sprintf(path, "%.15g %.15g [\n", origin.x, origin.y);
-  Tcl_AppendResult(wi->interp, path, NULL);
+  Tcl_AppendResult(wi->interp, path, (char *) NULL);
 
   /*
    * Emit code to draw the lines.
@@ -1421,7 +1421,7 @@ PostScript(ZnItem item,
   /* DrawText should not mess with anchors, they are already accounted for */
   sprintf(path, "] %d %g %g %g %s DrawText\n", fm.linespace, 0.0, 0.0, 
           alignment, (text->fill_pattern == ZnUnspecifiedImage) ? "false" : "true");
-  Tcl_AppendResult(wi->interp, path, NULL);
+  Tcl_AppendResult(wi->interp, path, (char *) NULL);
 
   return TCL_OK;
 }
@@ -1494,13 +1494,13 @@ Coords(ZnItem           item,
   
   if ((cmd == ZN_COORDS_ADD) || (cmd == ZN_COORDS_ADD_LAST) || (cmd == ZN_COORDS_REMOVE)) {
     Tcl_AppendResult(item->wi->interp,
-                     " texts can't add or remove vertices", NULL);
+                     " texts can't add or remove vertices", (char *) NULL);
     return TCL_ERROR;
   }
   else if ((cmd == ZN_COORDS_REPLACE) || (cmd == ZN_COORDS_REPLACE_ALL)) {
     if (*num_pts == 0) {
       Tcl_AppendResult(item->wi->interp,
-                       " coords command need 1 point on texts", NULL);
+                       " coords command need 1 point on texts", (char *) NULL);
       return TCL_ERROR;
     }
     text->pos = (*pts)[0];

--- a/generic/Track.c
+++ b/generic/Track.c
@@ -458,7 +458,7 @@ Init(ZnItem             item,
     ZnFIELD.InitFields(field_set);
   }
   else {
-    Tcl_AppendResult(wi->interp, " number of fields expected", NULL);
+    Tcl_AppendResult(wi->interp, " number of fields expected", (char *) NULL);
     return TCL_ERROR;
   }
   
@@ -2152,14 +2152,14 @@ Coords(ZnItem           item,
   
   if ((cmd == ZN_COORDS_ADD) || (cmd == ZN_COORDS_ADD_LAST) || (cmd == ZN_COORDS_REMOVE)) {
     Tcl_AppendResult(item->wi->interp, " ",
-                     item->class->name, "s can't add or remove vertices", NULL);
+                     item->class->name, "s can't add or remove vertices", (char *) NULL);
     return TCL_ERROR;
   }
   else if ((cmd == ZN_COORDS_REPLACE) || (cmd == ZN_COORDS_REPLACE_ALL)) {
     if (*num_pts == 0) {
       Tcl_AppendResult(item->wi->interp,
                        " coords command need 1 point on ",
-                       item->class->name, "s", NULL);
+                       item->class->name, "s", (char *) NULL);
       return TCL_ERROR;
     }
     if (item->class == ZnTrack) {
@@ -2224,7 +2224,7 @@ Part(ZnItem     item,
       }
       else {
       part_error:
-        Tcl_AppendResult(item->wi->interp, " invalid item part specification", NULL);
+        Tcl_AppendResult(item->wi->interp, " invalid item part specification", (char *) NULL);
         return TCL_ERROR;       
       }
     }

--- a/generic/Triangles.c
+++ b/generic/Triangles.c
@@ -121,7 +121,7 @@ Init(ZnItem             item,
   tr->points = NULL;
 
   if (*argc < 1) {
-    Tcl_AppendResult(wi->interp, " triangles coords expected", NULL);
+    Tcl_AppendResult(wi->interp, " triangles coords expected", (char *) NULL);
     return TCL_ERROR;
   }
   if (ZnParseCoordList(wi, (*args)[0], &points,
@@ -129,7 +129,7 @@ Init(ZnItem             item,
     return TCL_ERROR;
   }
   if (num_points < 3) {
-    Tcl_AppendResult(wi->interp, " malformed triangles coords, need at least 3 points", NULL);
+    Tcl_AppendResult(wi->interp, " malformed triangles coords, need at least 3 points", (char *) NULL);
     return TCL_ERROR;
   }
 
@@ -601,7 +601,7 @@ PostScript(ZnItem item,
 
   Tcl_AppendResult(wi->interp,
                    "/ShadingDict <<\n  /ShadingType 4\n  /ColorSpace /DeviceRGB\n",
-                   "  /DataSource [", NULL);
+                   "  /DataSource [", (char *) NULL);
   for (i = 0; i < num_points; i++) {
     if (i <= last_color_index) {
       color = ZnGetGradientColor(grads[i], 0.0, NULL);
@@ -621,14 +621,14 @@ PostScript(ZnItem item,
 
     sprintf(path, "%d %.15g %.15g %.4g %.4g %.4g ",
             edge, points[i].x, points[i].y, red, green, blue);
-    Tcl_AppendResult(wi->interp, path, NULL);
+    Tcl_AppendResult(wi->interp, path, (char *) NULL);
   }
-  Tcl_AppendResult(wi->interp, "]\n>> def\n", NULL);
-  Tcl_AppendResult(wi->interp, "<<\n  /PatternType 2\n  /Shading ShadingDict\n>>\n", NULL);
-  Tcl_AppendResult(wi->interp, "matrix identmatrix makepattern setpattern\n", NULL);
+  Tcl_AppendResult(wi->interp, "]\n>> def\n", (char *) NULL);
+  Tcl_AppendResult(wi->interp, "<<\n  /PatternType 2\n  /Shading ShadingDict\n>>\n", (char *) NULL);
+  Tcl_AppendResult(wi->interp, "matrix identmatrix makepattern setpattern\n", (char *) NULL);
   sprintf(path, "%.15g %.15g %.15g %.15g rectfill\n", bbox.orig.x, bbox.orig.y,
           bbox.corner.x - bbox.orig.x, bbox.corner.y - bbox.orig.y);
-  Tcl_AppendResult(wi->interp, path, NULL);
+  Tcl_AppendResult(wi->interp, path, (char *) NULL);
 
   return TCL_OK;
 }
@@ -737,7 +737,7 @@ Coords(ZnItem           item,
       ZnList    tmp;
       if (*num_pts == 0) {
         Tcl_AppendResult(item->wi->interp,
-                         " coords command need at least 3 points on triangles", NULL);
+                         " coords command need at least 3 points on triangles", (char *) NULL);
         return TCL_ERROR;
       }
       tmp = ZnListFromArray(*pts, *num_pts, sizeof(ZnPoint));
@@ -748,7 +748,7 @@ Coords(ZnItem           item,
     else {
       if (*num_pts == 0) {
         Tcl_AppendResult(item->wi->interp,
-                         " coords command need at least 1 point on triangles", NULL);
+                         " coords command need at least 1 point on triangles", (char *) NULL);
         return TCL_ERROR;
       }
       points = ZnListArray(tr->points);
@@ -758,7 +758,7 @@ Coords(ZnItem           item,
       }
       if ((index < 0) || ((unsigned int) index >= num_points)) {
       range_err:
-        Tcl_AppendResult(item->wi->interp, " coord index out of range", NULL);
+        Tcl_AppendResult(item->wi->interp, " coord index out of range", (char *) NULL);
         return TCL_ERROR;
       }
       points[index] = (*pts)[0];
@@ -807,7 +807,7 @@ Coords(ZnItem           item,
   else if (cmd == ZN_COORDS_REMOVE) {
     if (ZnListSize(tr->points) < 4) {
       Tcl_AppendResult(item->wi->interp,
-                       " triangles should keep at least 3 points", NULL);
+                       " triangles should keep at least 3 points", (char *) NULL);
       return TCL_ERROR;
     }
     points = ZnListArray(tr->points);

--- a/generic/Viewport.c
+++ b/generic/Viewport.c
@@ -185,7 +185,7 @@ Init(ZnItem             item,
   item->priority = 1;
   
   if (*argc < 1) {
-    Tcl_AppendResult(wi->interp, " viewport coords expected", NULL);
+    Tcl_AppendResult(wi->interp, " viewport coords expected", (char *) NULL);
     return TCL_ERROR;
   }
   if (ZnParseCoordList(wi, (*args)[0], &points,
@@ -193,7 +193,7 @@ Init(ZnItem             item,
     return TCL_ERROR;
   }
   if (num_points != 2) {
-    Tcl_AppendResult(wi->interp, " malformed viewport coords", NULL);
+    Tcl_AppendResult(wi->interp, " malformed viewport coords", (char *) NULL);
     return TCL_ERROR;
   };
   rect->coords[0] = points[0];
@@ -914,13 +914,13 @@ PostScript(ZnItem item,
   sprintf(path, "%.15g %.15g moveto %.15g %.15g lineto %.15g %.15g lineto %.15g %.15g lineto closepath\n",
           rect->dev[0].x, rect->dev[0].y, rect->dev[1].x, rect->dev[1].y,
           rect->dev[2].x, rect->dev[2].y, rect->dev[3].x, rect->dev[3].y);
-  Tcl_AppendResult(wi->interp, path, NULL);
+  Tcl_AppendResult(wi->interp, path, (char *) NULL);
 
   /*
    * And emit code code to stroke the outline... Viewport content won't be displayed, only the rectangle area
    */
   /*
-  Tcl_AppendResult(wi->interp, "0 setlinejoin 2 setlinecap\n", NULL);
+  Tcl_AppendResult(wi->interp, "0 setlinejoin 2 setlinecap\n", (char *) NULL);
   if (ZnPostscriptOutline(wi->interp, wi->ps_info, wi->win,
                           rect->line_width, rect->line_style,
                           rect->line_color, rect->line_pattern) != TCL_OK) {
@@ -1005,12 +1005,12 @@ Coords(ZnItem           item,
   ViewportItem rect = (ViewportItem) item;
 
   if ((cmd == ZN_COORDS_ADD) || (cmd == ZN_COORDS_ADD_LAST) || (cmd == ZN_COORDS_REMOVE)) {
-    Tcl_AppendResult(item->wi->interp, " viewports can't add or remove vertices", NULL);
+    Tcl_AppendResult(item->wi->interp, " viewports can't add or remove vertices", (char *) NULL);
     return TCL_ERROR;
   }
   else if (cmd == ZN_COORDS_REPLACE_ALL) {
     if (*num_pts != 2) {
-      Tcl_AppendResult(item->wi->interp, " coords command need 2 points on viewports", NULL);
+      Tcl_AppendResult(item->wi->interp, " coords command need 2 points on viewports", (char *) NULL);
       return TCL_ERROR;
     }
     rect->coords[0] = (*pts)[0];
@@ -1019,7 +1019,7 @@ Coords(ZnItem           item,
   }
   else if (cmd == ZN_COORDS_REPLACE) {
     if (*num_pts < 1) {
-      Tcl_AppendResult(item->wi->interp, " coords command need at least 1 point", NULL);
+      Tcl_AppendResult(item->wi->interp, " coords command need at least 1 point", (char *) NULL);
       return TCL_ERROR;
     }
     if (index < 0) {
@@ -1027,7 +1027,7 @@ Coords(ZnItem           item,
     }
     if ((index < 0) || (index > 1)) {
     range_err:
-      Tcl_AppendResult(item->wi->interp," incorrect coord index, should be between -2 and 1", NULL);
+      Tcl_AppendResult(item->wi->interp," incorrect coord index, should be between -2 and 1", (char *) NULL);
       return TCL_ERROR;
     }
     rect->coords[index] = (*pts)[0];

--- a/generic/Window.c
+++ b/generic/Window.c
@@ -828,7 +828,7 @@ PostScript(ZnItem item,
   sprintf(path, "\n%%%% %s item (%s, %d x %d)\n%.15g %.15g translate\n",
           Tk_Class(wind->win), Tk_PathName(wind->win), wind->real_width, wind->real_height,
           wind->pos_dev.x, wind->pos_dev.y);
-  Tcl_AppendResult(wi->interp, path, NULL);
+  Tcl_AppendResult(wi->interp, path, (char *) NULL);
 
   ComputeTransfoAndOrigin(item, &origin);
   
@@ -836,7 +836,7 @@ PostScript(ZnItem item,
           "%.15g %.15g translate\n"
           "1 -1 scale\n",
           wind->pos_dev.x, wind->pos_dev.y + wind->real_height);
-  Tcl_AppendResult(wi->interp, path, NULL);
+  Tcl_AppendResult(wi->interp, path, (char *) NULL);
 
   /* first try if the widget has its own "postscript" command. If it
    * exists, this will produce much better postscript than
@@ -853,13 +853,13 @@ PostScript(ZnItem item,
   Tcl_DStringFree(&buffer2);
 
   if (result == TCL_OK) {
-    Tcl_AppendResult(wi->interp, "50 dict begin\nsave\ngsave\n", NULL);
+    Tcl_AppendResult(wi->interp, "50 dict begin\nsave\ngsave\n", (char *) NULL);
     sprintf (path, "0 %d moveto %d 0 rlineto 0 -%d rlineto -%d",
              wind->real_height, wind->real_width, wind->real_height, wind->real_width);
-    Tcl_AppendResult(wi->interp, path, NULL);
+    Tcl_AppendResult(wi->interp, path, (char *) NULL);
     Tcl_AppendResult(wi->interp, " 0 rlineto closepath\n",
                      "1.000 1.000 1.000 setrgbcolor AdjustColor\nfill\ngrestore\n",
-                     Tcl_DStringValue(&buffer1), "\nrestore\nend\n\n\n", NULL);
+                     Tcl_DStringValue(&buffer1), "\nrestore\nend\n\n\n", (char *) NULL);
     Tcl_DStringFree(&buffer1);
 
     return result;
@@ -977,13 +977,13 @@ Coords(ZnItem           item,
   
   if ((cmd == ZN_COORDS_ADD) || (cmd == ZN_COORDS_ADD_LAST) || (cmd == ZN_COORDS_REMOVE)) {
     Tcl_AppendResult(item->wi->interp,
-                     " windows can't add or remove vertices", NULL);
+                     " windows can't add or remove vertices", (char *) NULL);
     return TCL_ERROR;
   }
   else if ((cmd == ZN_COORDS_REPLACE) || (cmd == ZN_COORDS_REPLACE_ALL)) {
     if (*num_pts == 0) {
       Tcl_AppendResult(item->wi->interp,
-                       " coords command need 1 point on windows", NULL);
+                       " coords command need 1 point on windows", (char *) NULL);
       return TCL_ERROR;
     }
     wind->pos = (*pts)[0];

--- a/generic/tkZinc.c
+++ b/generic/tkZinc.c
@@ -1387,14 +1387,14 @@ ZincObjCmd(ClientData           client_data,    /* Main window associated with
 #endif
 
   if (argc == 1) {
-    Tcl_AppendResult(interp, PACKAGE_VERSION, NULL);
-    Tcl_AppendResult(interp, " X11", NULL);
+    Tcl_AppendResult(interp, PACKAGE_VERSION, (char *) NULL);
+    Tcl_AppendResult(interp, " X11", (char *) NULL);
 #ifdef GL
 #  ifdef _WIN32
-    Tcl_AppendResult(interp, " GL", NULL);
+    Tcl_AppendResult(interp, " GL", (char *) NULL);
 #  else
     if (has_gl) {
-      Tcl_AppendResult(interp, " GL", NULL);
+      Tcl_AppendResult(interp, " GL", (char *) NULL);
     }
 #  endif
 #endif
@@ -2218,19 +2218,19 @@ ZnTagSearchScan(ZnWInfo   *wi,
             }
             else {
               Tcl_AppendResult(wi->interp, "unknown group in path \"",
-                               tag, "\"", NULL);
+                               tag, "\"", (char *) NULL);
               return TCL_ERROR;
             }
           }
           if (group->class != ZnGroup) {
             Tcl_AppendResult(wi->interp, "item is not a group in path \"",
-                             tag, "\"", NULL);
+                             tag, "\"", (char *) NULL);
             return TCL_ERROR;
           }
         }
         else {
           Tcl_AppendResult(wi->interp, "misplaced group id in path \"",
-                           tag, "\"", NULL);
+                           tag, "\"", (char *) NULL);
           return TCL_ERROR;
         }
       }
@@ -2253,7 +2253,7 @@ ZnTagSearchScan(ZnWInfo   *wi,
                                 ZnListSize(ZnWorkStrings));
     if (group == ZN_NO_ITEM) {
       Tcl_AppendResult(wi->interp, "path does not lead to a valid group\"",
-                       tag, "\"", NULL);
+                       tag, "\"", (char *) NULL);
       return TCL_ERROR;
     }
 
@@ -3379,7 +3379,7 @@ FindItems(ZnWInfo       *wi,
           if (strcmp(str, "override") != 0) { 
             Tcl_AppendResult(wi->interp,
                              "recursive should be a boolean value or ",
-                             "override \"", str, "\"", NULL);
+                             "override \"", str, "\"", (char *) NULL);
             return TCL_ERROR;
           }
           ps.recursive = True;
@@ -3429,7 +3429,7 @@ FindItems(ZnWInfo       *wi,
           if (strcmp(str, "override") != 0) { 
             Tcl_AppendResult(wi->interp,
                              "recursive should be a boolean value or ",
-                             "override \"", str, "\"", NULL);
+                             "override \"", str, "\"", (char *) NULL);
             return TCL_ERROR;
           }
           ps.recursive = True;
@@ -3467,7 +3467,7 @@ FindItems(ZnWInfo       *wi,
           if (strcmp(str, "override") != 0) { 
             Tcl_AppendResult(wi->interp,
                              "recursive should be a boolean value or ",
-                             "override \"", str, "\"", NULL);
+                             "override \"", str, "\"", (char *) NULL);
             return TCL_ERROR;
           }
           ps.recursive = True;
@@ -3511,7 +3511,7 @@ FindItems(ZnWInfo       *wi,
       cls = ZnLookupItemClass(Tcl_GetString(args[first+1]));
       if (!cls) {
         Tcl_AppendResult(wi->interp, "unknown item type \"",
-                         Tcl_GetString(args[first+1]), "\"", NULL);
+                         Tcl_GetString(args[first+1]), "\"", (char *) NULL);
         return TCL_ERROR;
       }
       
@@ -3568,7 +3568,7 @@ ZnParseCoordList(ZnWInfo        *wi,
   result = Tcl_ListObjGetElements(wi->interp, arg, &num_elems, &elems);
   if (result == TCL_ERROR) {
   coord_error:
-    Tcl_AppendResult(wi->interp, " malformed coord list", NULL);
+    Tcl_AppendResult(wi->interp, " malformed coord list", (char *) NULL);
     return TCL_ERROR;
   }
   if (num_elems == 0) {
@@ -3710,7 +3710,7 @@ Contour(ZnWInfo *wi,
   result = ZnItemWithTagOrId(wi, args[2], &item, search_var);
   if ((result == TCL_ERROR) || (item == ZN_NO_ITEM)){
     Tcl_AppendResult(wi->interp, "unknown item \"", Tcl_GetString(args[2]),
-                     "\"", NULL);
+                     "\"", (char *) NULL);
     return TCL_ERROR;
   }
   if (!item->class->Contour) {
@@ -3743,7 +3743,7 @@ Contour(ZnWInfo *wi,
   if ((Tcl_GetIntFromObj(wi->interp, args[4], &winding_flag) != TCL_OK) ||
       (winding_flag < -1) || (winding_flag > 1)) {
     Tcl_AppendResult(wi->interp, " incorrect winding flag, should be -1, 0, 1, \"",
-                     Tcl_GetString(args[4]), "\"", NULL);
+                     Tcl_GetString(args[4]), "\"", (char *) NULL);
     return TCL_ERROR;
   }
   index = ZnListTail;
@@ -3751,7 +3751,7 @@ Contour(ZnWInfo *wi,
     /* Look for an index value. */
     if (Tcl_GetLongFromObj(wi->interp, args[5], &index) != TCL_OK) {
       Tcl_AppendResult(wi->interp, " incorrect contour index \"",
-                       Tcl_GetString(args[5]), "\"", NULL);
+                       Tcl_GetString(args[5]), "\"", (char *) NULL);
       return TCL_ERROR;
     }
     argc--;
@@ -3808,7 +3808,7 @@ Contour(ZnWInfo *wi,
       if (winding_flag == 0) {
         Tcl_AppendResult(wi->interp,
                          "Must supply an explicit winding direction (-1, 1)\nwhen adding a contour from an item",
-                         NULL);
+                         (char *) NULL);
         return TCL_ERROR;
       }
       /*
@@ -3819,7 +3819,7 @@ Contour(ZnWInfo *wi,
       if (!shape->class->GetContours &&
           !shape->class->GetClipVertices) {
         Tcl_AppendResult(wi->interp, "class: \"", shape->class->name,
-                         "\" can't give a polygonal shape", NULL);
+                         "\" can't give a polygonal shape", (char *) NULL);
         return TCL_ERROR;
       }
       if (!shape->class->GetContours) {
@@ -3981,12 +3981,12 @@ Coords(ZnWInfo          *wi,
   result = ZnItemWithTagOrId(wi, args[2], &item, search_var);
   if ((result == TCL_ERROR) || (item == ZN_NO_ITEM)) {
     Tcl_AppendResult(wi->interp, " unknown item \"",
-                     Tcl_GetString(args[2]), "\"", NULL);
+                     Tcl_GetString(args[2]), "\"", (char *) NULL);
     return TCL_ERROR;
   }
   if (!item->class->Coords) {
     Tcl_AppendResult(wi->interp, " ", item->class->name,
-                     " does not support the coords command", NULL);
+                     " does not support the coords command", (char *) NULL);
     return TCL_ERROR;
   }
   num_points = 0;
@@ -4059,12 +4059,12 @@ Coords(ZnWInfo          *wi,
     if (((argc == 5) && (cmd != ZN_COORDS_ADD) && (cmd != ZN_COORDS_REMOVE)) ||
         (argc == 6) || (argc == 7)) {
       Tcl_AppendResult(wi->interp, " incorrect contour index \"",
-                       Tcl_GetString(args[i]), "\"", NULL);
+                       Tcl_GetString(args[i]), "\"", (char *) NULL);
       return TCL_ERROR;
     }
     else if ((argc == 5) && (cmd != ZN_COORDS_ADD)) {
       Tcl_AppendResult(wi->interp, " incorrect coord index \"",
-                       Tcl_GetString(args[i]), "\"", NULL);
+                       Tcl_GetString(args[i]), "\"", (char *) NULL);
       return TCL_ERROR;
     }
     else if (ZnParseCoordList(wi, args[argc-1], &points,
@@ -4117,7 +4117,7 @@ Coords(ZnWInfo          *wi,
     Tcl_ResetResult(wi->interp);
     if ((argc == 7) || ((argc == 6) && (cmd != ZN_COORDS_ADD))) {
       Tcl_AppendResult(wi->interp, " incorrect coord index \"",
-                       Tcl_GetString(args[i]), "\"", NULL);
+                       Tcl_GetString(args[i]), "\"", (char *) NULL);
       return TCL_ERROR;
     }
     else if (ZnParseCoordList(wi, args[argc-1], &points,
@@ -4321,14 +4321,14 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
       }
       cls = ZnLookupItemClass(str);
       if (!cls) {
-        Tcl_AppendResult(interp, "unknown item type \"", str, "\"", NULL);
+        Tcl_AppendResult(interp, "unknown item type \"", str, "\"", (char *) NULL);
         goto error;
       }
       result = ZnItemWithTagOrId(wi, args[3], &group, &search_var);
       if ((result == TCL_ERROR) || (group == ZN_NO_ITEM) ||
           (group->class != ZnGroup)) {
         Tcl_AppendResult(interp, ", group item expected, got \"",
-                         Tcl_GetString(args[3]), "\"", NULL);
+                         Tcl_GetString(args[3]), "\"", (char *) NULL);
         goto error;
       }
       
@@ -4375,7 +4375,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
       if ((result == TCL_ERROR) || (item == ZN_NO_ITEM) ||
           ISCLEAR(item->class->flags, ZN_CLASS_HAS_ANCHORS)) {
         Tcl_AppendResult(interp, "unknown item or doesn't support anchors \"",
-                         Tcl_GetString(args[2]), NULL);
+                         Tcl_GetString(args[2]), (char *) NULL);
         goto error;
       }
       if (Tk_GetAnchor(interp, Tcl_GetString(args[3]), &anchor)) {
@@ -4397,7 +4397,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
      */
   case ZN_W_BECOMES:
     {
-      Tcl_AppendResult(interp, "Command not yet implemented", NULL);
+      Tcl_AppendResult(interp, "Command not yet implemented", (char *) NULL);
       goto error;
     }
     break;
@@ -4436,20 +4436,20 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
         }
         else {
           Tcl_AppendResult(interp, "bbox option should be -field numField or -label",
-                           NULL);
+                           (char *) NULL);
           goto error;
         }
         result = ZnItemWithTagOrId(wi, args[0], &item, &search_var);
         if ((result == TCL_ERROR) || (item == ZN_NO_ITEM) ||
             ! item->class->GetFieldSet) {
           Tcl_AppendResult(interp, "unknown item or doesn't support fields \"",
-                           Tcl_GetString(args[0]), "\"", NULL);
+                           Tcl_GetString(args[0]), "\"", (char *) NULL);
           goto error;
         }
         fs = item->class->GetFieldSet(item);
         if (field >= 0) {
           if ((unsigned int) field >= fs->num_fields) {
-            Tcl_AppendResult(interp, "field index is out of bounds", NULL);
+            Tcl_AppendResult(interp, "field index is out of bounds", (char *) NULL);
             goto error;   
           }
           ZnFIELD.GetFieldBBox(fs, field, &bbox);
@@ -4473,7 +4473,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
            */
           str = Tcl_GetString(args[i]);
           if (*str == '-') {
-            Tcl_AppendResult(interp, "bbox options should be specified before any tag", NULL);
+            Tcl_AppendResult(interp, "bbox options should be specified before any tag", (char *) NULL);
             goto error;
           }
           if (ZnTagSearchScan(wi, args[i], &search_var) == TCL_ERROR) {
@@ -4526,7 +4526,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
         }
         entry = Tcl_FindHashEntry(wi->id_table, (char *) id);
         if (entry == NULL) {
-          Tcl_AppendResult(interp, "item \"", str, "\" doesn't exist", NULL);
+          Tcl_AppendResult(interp, "item \"", str, "\" doesn't exist", (char *) NULL);
           goto error;
         }
         item = elem = Tcl_GetHashValue(entry);
@@ -4548,7 +4548,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
             elem = EncodeItemPart(item, part);
           }
           else {
-            Tcl_AppendResult(interp, "item \"", str, "\" doesn't have parts", NULL);
+            Tcl_AppendResult(interp, "item \"", str, "\" doesn't have parts", (char *) NULL);
             goto error;
           }
         }
@@ -4617,7 +4617,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
           Tcl_ResetResult(interp);
           Tcl_AppendResult(interp, "requested illegal events; ",
                            "only key, button, motion, enter, leave ",
-                           "mousewheel and virtual events may be used", NULL);
+                           "mousewheel and virtual events may be used", (char *) NULL);
           goto error;
         }
       }
@@ -4716,7 +4716,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
       if (scan == item) {
         Tcl_AppendResult(interp, "\"", Tcl_GetString(args[3]),
                          "\" is a descendant of \"", Tcl_GetString(args[2]),
-                         "\" and can't be used as its parent", NULL);
+                         "\" and can't be used as its parent", (char *) NULL);
         goto error;
       }
       if (argc == 5) {
@@ -4908,7 +4908,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
           if (Tcl_GetString(args[3])[0] != 0) { 
             Tcl_AppendResult(interp, "invalid field index \"",
                              Tcl_GetString(args[3]),
-                             "\", should be a positive integer", NULL);
+                             "\", should be a positive integer", (char *) NULL);
             goto error;
           }
         }
@@ -4955,7 +4955,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
           if (Tcl_GetString(args[3])[0] != 0) { 
             Tcl_AppendResult(interp, "invalid field index \"",
                              Tcl_GetString(args[3]),
-                             "\", should be a positive integer", NULL);
+                             "\", should be a positive integer", (char *) NULL);
             goto error;
           }
         }
@@ -5131,7 +5131,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
           if (Tcl_GetString(args[3])[0] != 0) { 
             Tcl_AppendResult(interp, "invalid field index \"",
                              Tcl_GetString(args[3]),
-                             "\", should be a positive integer", NULL);
+                             "\", should be a positive integer", (char *) NULL);
             goto error;
           }
         }
@@ -5303,7 +5303,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
           if (Tcl_GetString(args[3])[0] != 0) {
             Tcl_AppendResult(interp, "invalid field index \"",
                              Tcl_GetString(args[3]),
-                             "\", should be a positive integer", NULL);
+                             "\", should be a positive integer", (char *) NULL);
             goto error;
           }
         }
@@ -5323,7 +5323,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
         }
       }
       Tcl_AppendResult(interp, "can't find an indexable item \"",
-                       Tcl_GetString(args[2]), "\"", NULL);
+                       Tcl_GetString(args[2]), "\"", (char *) NULL);
       goto error;
     }
     break;
@@ -5348,7 +5348,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
           if (Tcl_GetString(args[3])[0] != 0) { 
             Tcl_AppendResult(interp, "invalid field index \"",
                              Tcl_GetString(args[3]),
-                             "\", should be a positive integer", NULL);
+                             "\", should be a positive integer", (char *) NULL);
             goto error;
           }
         }
@@ -5406,7 +5406,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
           if (Tcl_GetString(args[3])[0] != 0) {
             Tcl_AppendResult(interp, "invalid field index \"",
                              Tcl_GetString(args[3]),
-                             "\", should be a positive integer", NULL);
+                             "\", should be a positive integer", (char *) NULL);
             goto error;
           }
         }
@@ -5440,7 +5440,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
           if (Tcl_GetString(args[3])[0] != 0) { 
             Tcl_AppendResult(interp, "invalid field index \"",
                              Tcl_GetString(args[3]),
-                             "\", should be a positive integer", NULL);
+                             "\", should be a positive integer", (char *) NULL);
             goto error;
           }
         }
@@ -5462,12 +5462,12 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
                                         ZnFIELD.attr_desc, argc, args);
             }
             else {
-              Tcl_AppendResult(interp, "field index out of bound", NULL);
+              Tcl_AppendResult(interp, "field index out of bound", (char *) NULL);
               goto error;
             }
           }
           else {
-            Tcl_AppendResult(interp, "the item does not support fields", NULL);
+            Tcl_AppendResult(interp, "the item does not support fields", (char *) NULL);
             goto error;
           }
           goto done;
@@ -5517,7 +5517,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
         }
         if (mark == ZN_NO_ITEM) {
           Tcl_AppendResult(interp, "unknown tag or item \"",
-                           Tcl_GetString(args[3]), "\"", NULL);
+                           Tcl_GetString(args[3]), "\"", (char *) NULL);
           goto error;
         }
       }
@@ -5629,7 +5629,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
         mark = ZnTagSearchFirst(search_var);
         if (mark == ZN_NO_ITEM) {
           Tcl_AppendResult(interp, "unknown tag or item \"",
-                           Tcl_GetString(args[3]), "\"", NULL);
+                           Tcl_GetString(args[3]), "\"", (char *) NULL);
           goto error;
         }
       }
@@ -5725,7 +5725,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
       }
       str = Tcl_GetString(args[2]);
       if (strlen(str) == 0) {
-        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", NULL);
+        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", (char *) NULL);
         goto error;
       }
       entry = Tcl_FindHashEntry(wi->t_table, str);
@@ -5777,7 +5777,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
       }
       str = Tcl_GetString(args[2]);
       if (strlen(str) == 0) {
-        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", NULL);
+        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", (char *) NULL);
         goto error;
       }
       entry = Tcl_FindHashEntry(wi->t_table, str);
@@ -5849,7 +5849,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
         }
         if (item == ZN_NO_ITEM) {
           Tcl_AppendResult(interp, "can't find an indexable item \"",
-                           Tcl_GetString(args[3]), "\"", NULL);
+                           Tcl_GetString(args[3]), "\"", (char *) NULL);
           goto error;
         }
       }
@@ -5864,7 +5864,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
             if (Tcl_GetString(args[4])[0] != 0) {
               Tcl_AppendResult(interp, "invalid field index \"",
                                Tcl_GetString(args[4]),
-                               "\", should be a positive integer", NULL);
+                               "\", should be a positive integer", (char *) NULL);
               goto error;
             }
           }
@@ -5951,7 +5951,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
       }
       str = Tcl_GetString(args[2]);
       if (strlen(str) == 0) {
-        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", NULL);
+        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", (char *) NULL);
         goto error;
       }
       entry = Tcl_FindHashEntry(wi->t_table, str);
@@ -6012,7 +6012,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
      */
   case ZN_W_TAPPLY:
     {
-      Tcl_AppendResult(interp, "Command not yet implemented", NULL);
+      Tcl_AppendResult(interp, "Command not yet implemented", (char *) NULL);
       goto error;
     }
     break;
@@ -6038,7 +6038,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
       
       str = Tcl_GetString(args[3]);
       if (strlen(str) == 0) {
-        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", NULL);
+        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", (char *) NULL);
         goto error;
       }
       entry = Tcl_FindHashEntry(wi->t_table, str);
@@ -6060,7 +6060,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
 
       str = Tcl_GetString(args[2]);
       if (strlen(str) == 0) {
-        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", NULL);
+        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", (char *) NULL);
         goto error;
       }
       entry = Tcl_FindHashEntry(wi->t_table, str);
@@ -6159,7 +6159,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
       }
       str = Tcl_GetString(args[2]);
       if (strlen(str) == 0) {
-        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", NULL);
+        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", (char *) NULL);
         goto error;
       }
       entry = Tcl_FindHashEntry(wi->t_table, str);
@@ -6229,7 +6229,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
          */
         tag = Tcl_GetString(args[2]);
         if (strlen(tag) == 0) {
-          Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", NULL);
+          Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", (char *) NULL);
           goto error;
         }
         if (strcmp(tag, "device") == 0) {
@@ -6261,7 +6261,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
        */
       tag = Tcl_GetString(args[argc-2]);
       if (strlen(tag) == 0) {
-        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", NULL);
+        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", (char *) NULL);
         goto error;
       }
       if (strcmp(tag, "device") == 0) {
@@ -6301,7 +6301,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
       if (ZnParseCoordList(wi, args[argc-1], &p,
                            &controls, &num_points, &old_format) == TCL_ERROR) {
         Tcl_AppendResult(interp, " invalid coord list \"",
-                         Tcl_GetString(args[argc-1]), "\"", NULL);
+                         Tcl_GetString(args[argc-1]), "\"", (char *) NULL);
         goto error;
       }
       l = Tcl_GetObjResult(interp);
@@ -6351,7 +6351,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
       }
       str = Tcl_GetString(args[2]);
       if (strlen(str) == 0) {
-        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", NULL);
+        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", (char *) NULL);
         goto error;
       }
       entry = Tcl_FindHashEntry(wi->t_table, str);
@@ -6399,7 +6399,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
       }
       str = Tcl_GetString(args[2]);
       if (strlen(str) == 0) {
-        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", NULL);
+        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", (char *) NULL);
         goto error;
       }
       entry = Tcl_FindHashEntry(wi->t_table, str);
@@ -6527,7 +6527,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
       }
       str = Tcl_GetString(args[2]);
       if (strlen(str) == 0) {
-        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", NULL);
+        Tcl_AppendResult(interp, " must provide a valid tagOrIdOrTransform", (char *) NULL);
         goto error;
       }
       entry = Tcl_FindHashEntry(wi->t_table, str);
@@ -6592,7 +6592,7 @@ WidgetObjCmd(ClientData         client_data,    /* Information about the widget.
       }
       if (item == ZN_NO_ITEM) {
         Tcl_AppendResult(interp, "can't find a suitable item \"",
-                         Tcl_GetString(args[2]), "\"", NULL);
+                         Tcl_GetString(args[2]), "\"", (char *) NULL);
         goto error;
       }
       if (Tcl_GetDoubleFromObj(interp, args[3], &d) == TCL_ERROR) {

--- a/zinclib.d/doc/html/Zinc_8cpp.html
+++ b/zinclib.d/doc/html/Zinc_8cpp.html
@@ -417,7 +417,7 @@ All arguments of the function are Tcl_Obj. To accelerate their call, there is a 
     <span class="keywordtype">int</span> result = (fct);      \
     <span class="keywordflow">if</span> (result != TCL_OK)    \
     {                        \
-      Tcl_AppendResult (Zinc::interp, msg, NULL); \
+      Tcl_AppendResult (Zinc::interp, msg, (char *) NULL); \
       <span class="keywordflow">return</span> TCL_ERROR;      \
     }                        \
   }

--- a/zinclib.d/src/Zinc.cpp
+++ b/zinclib.d/src/Zinc.cpp
@@ -1858,7 +1858,7 @@ void Zinc::itemMatrix (ZincItem * item,
     int result = (fct);      \
     if (result != TCL_OK)    \
     {                        \
-      Tcl_AppendResult (Zinc::interp, msg, NULL); \
+      Tcl_AppendResult (Zinc::interp, msg, (char *) NULL); \
       return TCL_ERROR;      \
     }                        \
   }


### PR DESCRIPTION
For portability, the `NULL` sentinel passed to `Tcl_AppendResult()` should be cast to `(char *)`.